### PR TITLE
started brep in mem refactor

### DIFF
--- a/src/cad_to_dagmc/brep_part_finder.py
+++ b/src/cad_to_dagmc/brep_part_finder.py
@@ -74,20 +74,6 @@ def get_part_properties_from_shapes(shapes: Iterable) -> dict:
     return all_part_details
 
 
-def get_part_properties_from_file(filename: Union[str, PathLike]):
-    """Imports a Brep CAD file and returns the unique identify details of each Solid
-
-    Args:
-        filename: the filename of the brep file
-    """
-
-    shapes = Shape.importBrep(filename)
-
-    my_brep_part_details = get_part_properties_from_shapes(shapes)
-
-    return my_brep_part_details
-
-
 def get_matching_part_id(
     brep_part_properties: dict,
     center_x: float = None,

--- a/src/cad_to_dagmc/brep_to_h5m.py
+++ b/src/cad_to_dagmc/brep_to_h5m.py
@@ -75,7 +75,7 @@ def mesh_brep(
     gmsh.initialize()
     gmsh.option.setNumber("General.Terminal", 1)
     gmsh.model.add("made_with_brep_to_h5m_package")
-    volumes = gmsh.model.occ.importShapesNativePointer(brep_object._address())
+    volumes = gmsh.model.occ.importShapesNativePointer(brep_object.wrapped._address())
     # gmsh.model.occ.importShapes(brep_object)
     gmsh.model.occ.synchronize()
 

--- a/src/cad_to_dagmc/brep_to_h5m.py
+++ b/src/cad_to_dagmc/brep_to_h5m.py
@@ -5,7 +5,7 @@ import typing
 
 
 def brep_to_h5m(
-    brep_filename: str,
+    brep_object: str,
     material_tags: typing.Iterable[str],
     h5m_filename: str = "dagmc.h5m",
     min_mesh_size: float = 30,
@@ -16,7 +16,7 @@ def brep_to_h5m(
     will therefore need to have Gmsh installed to work.
 
     Args:
-        brep_filename: the filename of the Brep file to convert
+        brep_object: the filename of the Brep file to convert
         material_tags: A list of material tags to tag the DAGMC volumes with.
             Should be in the same order as the volumes
         h5m_filename: the filename of the DAGMC h5m file to write
@@ -31,7 +31,7 @@ def brep_to_h5m(
     """
 
     gmsh, volumes = mesh_brep(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         min_mesh_size=min_mesh_size,
         max_mesh_size=max_mesh_size,
         mesh_algorithm=mesh_algorithm,
@@ -47,7 +47,7 @@ def brep_to_h5m(
 
 
 def mesh_brep(
-    brep_filename: str,
+    brep_object: str,
     min_mesh_size: float = 30,
     max_mesh_size: float = 10,
     mesh_algorithm: int = 1,
@@ -56,7 +56,7 @@ def mesh_brep(
     Gmsh.
 
     Args:
-        brep_filename: the filename of the Brep file to convert
+        brep_object: the filename of the Brep file to convert
         min_mesh_size: the minimum mesh element size to use in Gmsh. Passed
             into gmsh.option.setNumber("Mesh.MeshSizeMin", min_mesh_size)
         max_mesh_size: the maximum mesh element size to use in Gmsh. Passed
@@ -68,14 +68,15 @@ def mesh_brep(
         The gmsh object and volumes in Brep file
     """
 
-    if not Path(brep_filename).is_file():
-        msg = f"The specified brep ({brep_filename}) file was not found"
-        raise FileNotFoundError(msg)
+    # if not Path(brep_object).is_file():
+    #     msg = f"The specified brep ({brep_object}) file was not found"
+    #     raise FileNotFoundError(msg)
 
     gmsh.initialize()
     gmsh.option.setNumber("General.Terminal", 1)
     gmsh.model.add("made_with_brep_to_h5m_package")
-    volumes = gmsh.model.occ.importShapes(brep_filename)
+    volumes = gmsh.model.occ.importShapesNativePointer(brep_object._address())
+    # gmsh.model.occ.importShapes(brep_object)
     gmsh.model.occ.synchronize()
 
     gmsh.option.setNumber("Mesh.Algorithm", mesh_algorithm)

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -159,6 +159,6 @@ class CadToDagmc:
 
         bldr.Images()
 
-        merged_solid = cq.Compound(bldr.Shape())#.wrapped
+        merged_solid = cq.Compound(bldr.Shape())  # .wrapped
 
         return merged_solid

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -101,11 +101,11 @@ class CadToDagmc:
     ):
         brep_shape = self._merge_surfaces()
 
-        tmp_brep_filename = mkstemp(suffix=".brep", prefix="paramak_")[1]
-        brep_shape.exportBrep(tmp_brep_filename)
+        # tmp_brep_filename = mkstemp(suffix=".brep", prefix="paramak_")[1]
+        # brep_shape.exportBrep(tmp_brep_filename)
 
-        if verbose:
-            print(f"Brep file saved to {tmp_brep_filename}")
+        # if verbose:
+        #     print(f"Brep file saved to {tmp_brep_filename}")
 
         brep_file_part_properties = get_part_properties_from_shapes(brep_shape)
 
@@ -140,9 +140,9 @@ class CadToDagmc:
 
         bldr = OCP.BOPAlgo.BOPAlgo_Splitter()
 
-        if len(self.parts) == 1:
-            # merged_solid = cq.Compound(solids)
-            return self.parts[0]
+        # if len(self.parts) == 1:
+        #     # merged_solid = cq.Compound(solids)
+        #     return self.parts[0]
 
         for solid in self.parts:
             # checks if solid is a compound as .val() is not needed for compounds
@@ -159,6 +159,6 @@ class CadToDagmc:
 
         bldr.Images()
 
-        merged_solid = cq.Compound(bldr.Shape())
+        merged_solid = cq.Compound(bldr.Shape())#.wrapped
 
         return merged_solid

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -124,7 +124,7 @@ class CadToDagmc:
             material_tags_in_brep_order.append(self.material_tags[shape_id - 1])
 
         brep_to_h5m(
-            brep_filename=tmp_brep_filename,
+            brep_object=brep_shape,
             material_tags=material_tags_in_brep_order,
             h5m_filename=filename,
             min_mesh_size=min_mesh_size,

--- a/tests/test_brep_to_h5m/test_h5m_in_transport.py
+++ b/tests/test_brep_to_h5m/test_h5m_in_transport.py
@@ -1,7 +1,8 @@
 import openmc
 from cad_to_dagmc.brep_to_h5m import brep_to_h5m
 import math
-
+import cadquery as cq
+from cad_to_dagmc import CadToDagmc
 from cad_to_dagmc.brep_to_h5m import (
     mesh_brep,
     mesh_to_h5m_in_memory_method,
@@ -123,7 +124,7 @@ def transport_particles_on_h5m_geometry(
 
 
 def test_transport_on_h5m_with_6_volumes():
-    brep_filename = "tests/test_brep_to_h5m/test_brep_file.brep"
+    brep_object = "tests/test_brep_to_h5m/test_brep_file.brep"
     h5m_filename = "test_brep_file.h5m"
     volumes = 6
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
@@ -145,29 +146,31 @@ def test_transport_on_h5m_with_6_volumes():
 
 
 def test_transport_on_h5m_with_1_volumes():
-    brep_filename = "tests/test_brep_to_h5m/one_cube.brep"
-    h5m_filename = "one_cube.h5m"
+    result = cq.Workplane("front").box(2.0, 2.0, 0.5)
+
     volumes = 1
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
-    brep_to_h5m(
-        brep_object=brep_object,
-        material_tags=material_tags,
-        h5m_filename=h5m_filename,
-        min_mesh_size=30,
-        max_mesh_size=50,
-        mesh_algorithm=1,
+    my_model = CadToDagmc()
+
+    my_model.add_cadquery_object(
+        result,
+        material_tags=["mat1"],
+    )
+
+    my_model.export_dagmc_h5m_file(
+        filename="cadquery_objects_and_stp_files.h5m", max_mesh_size=1, min_mesh_size=0.1
     )
 
     transport_particles_on_h5m_geometry(
-        h5m_filename=h5m_filename,
+        h5m_filename="one_cube.h5m",
         material_tags=material_tags,
         nuclides=["H1"] * len(material_tags),
     )
 
 
 def test_transport_on_h5m_with_2_joined_volumes():
-    brep_filename = "tests/test_brep_to_h5m/test_two_joined_cubes.brep"
+    brep_object = "tests/test_brep_to_h5m/test_two_joined_cubes.brep"
     h5m_filename = "test_two_joined_cubes.h5m"
     volumes = 2
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
@@ -189,7 +192,7 @@ def test_transport_on_h5m_with_2_joined_volumes():
 
 
 def test_transport_on_h5m_with_2_sep_volumes():
-    brep_filename = "tests/test_brep_to_h5m/test_two_sep_cubes.brep"
+    brep_object = "tests/test_brep_to_h5m/test_two_sep_cubes.brep"
     h5m_filename = "test_two_sep_cubes.h5m"
     volumes = 2
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
@@ -211,7 +214,7 @@ def test_transport_on_h5m_with_2_sep_volumes():
 
 
 def test_transport_result_h5m_with_2_sep_volumes():
-    brep_filename = "tests/test_brep_to_h5m/test_two_sep_cubes.brep"
+    brep_object = "tests/test_brep_to_h5m/test_two_sep_cubes.brep"
     h5m_filename = "test_two_sep_cubes.h5m"
     volumes = 2
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
@@ -249,7 +252,7 @@ def test_transport_result_h5m_with_2_sep_volumes():
 
 
 def test_stl_vs_in_memory_1_volume():
-    brep_filename = "tests/test_brep_to_h5m/one_cube.brep"
+    brep_object = "tests/test_brep_to_h5m/one_cube.brep"
     volumes = 1
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
@@ -274,7 +277,7 @@ def test_stl_vs_in_memory_1_volume():
 
 
 def test_stl_vs_in_memory_2_joined_volume():
-    brep_filename = "tests/test_brep_to_h5m/test_two_joined_cubes.brep"
+    brep_object = "tests/test_brep_to_h5m/test_two_joined_cubes.brep"
     volumes = 2
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 

--- a/tests/test_brep_to_h5m/test_h5m_in_transport.py
+++ b/tests/test_brep_to_h5m/test_h5m_in_transport.py
@@ -159,7 +159,9 @@ def test_transport_on_h5m_with_1_volumes():
     )
 
     my_model.export_dagmc_h5m_file(
-        filename="cadquery_objects_and_stp_files.h5m", max_mesh_size=1, min_mesh_size=0.1
+        filename="cadquery_objects_and_stp_files.h5m",
+        max_mesh_size=1,
+        min_mesh_size=0.1,
     )
 
     transport_particles_on_h5m_geometry(

--- a/tests/test_brep_to_h5m/test_h5m_in_transport.py
+++ b/tests/test_brep_to_h5m/test_h5m_in_transport.py
@@ -129,7 +129,7 @@ def test_transport_on_h5m_with_6_volumes():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -151,7 +151,7 @@ def test_transport_on_h5m_with_1_volumes():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -173,7 +173,7 @@ def test_transport_on_h5m_with_2_joined_volumes():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -195,7 +195,7 @@ def test_transport_on_h5m_with_2_sep_volumes():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -217,7 +217,7 @@ def test_transport_result_h5m_with_2_sep_volumes():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -232,7 +232,7 @@ def test_transport_result_h5m_with_2_sep_volumes():
     )
 
     brep_to_h5m(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         material_tags=material_tags,
         h5m_filename=h5m_filename,
         min_mesh_size=30,
@@ -254,7 +254,7 @@ def test_stl_vs_in_memory_1_volume():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     gmsh, volumes = mesh_brep(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         min_mesh_size=1,
         max_mesh_size=5,
         mesh_algorithm=1,
@@ -279,7 +279,7 @@ def test_stl_vs_in_memory_2_joined_volume():
     material_tags = [f"material_{n}" for n in range(1, volumes + 1)]
 
     gmsh, volumes = mesh_brep(
-        brep_filename=brep_filename,
+        brep_object=brep_object,
         min_mesh_size=1,
         max_mesh_size=5,
         mesh_algorithm=1,

--- a/tests/test_brep_to_h5m/test_python_api.py
+++ b/tests/test_brep_to_h5m/test_python_api.py
@@ -1,3 +1,4 @@
+import cadquery as cq
 import os
 from pathlib import Path
 
@@ -51,7 +52,7 @@ class TestApiUsage:
 
         os.system("rm test_brep_file.h5m")
         brep_to_h5m(
-            brep_filename="tests/test_brep_to_h5m/test_brep_file.brep",
+            brep_object="tests/test_brep_to_h5m/test_brep_file.brep",
             material_tags=[
                 "material_for_volume_1",
                 "material_for_volume_2",
@@ -72,8 +73,11 @@ class TestApiUsage:
         """Checks the reducing max_mesh_size value increases the file size"""
 
         os.system("rm *.h5m")
+        # brep file made with
+        # my_reactor = paramak.FlfSystemCodeReactor()
+        result = cq.importers.importStep("tests/test_brep_to_h5m/test_brep_file.brep")
         brep_to_h5m(
-            brep_filename="tests/test_brep_to_h5m/test_brep_file.brep",
+            brep_object=result,
             material_tags=[
                 "material_for_volume_1",
                 "material_for_volume_2",
@@ -88,7 +92,7 @@ class TestApiUsage:
             mesh_algorithm=1,
         )
         brep_to_h5m(
-            brep_filename="tests/test_brep_to_h5m/test_brep_file.brep",
+            brep_object=result,
             material_tags=[
                 "material_for_volume_1",
                 "material_for_volume_2",
@@ -116,7 +120,7 @@ class TestApiUsage:
         test_h5m_filename = "test_dagmc.h5m"
         os.system(f"rm {test_h5m_filename}")
         returned_filename = brep_to_h5m(
-            brep_filename="tests/test_brep_to_h5m/test_brep_file.brep",
+            brep_object="tests/test_brep_to_h5m/test_brep_file.brep",
             material_tags=[
                 "mat1",
                 "mat2",


### PR DESCRIPTION
this should remove the need to write a brep file when going from cadquery to gmsh

```python
from cad_to_dagmc import CadToDagmc
import cadquery as cq
import OCP

result = cq.Workplane("front").box(2.0, 2.0, 0.5)

volumes = 1
material_tags = [f"material_{n}" for n in range(1, volumes + 1)]

my_model = CadToDagmc()

my_model.add_cadquery_object(
    result,
    material_tags=["mat1"],
)

bldr = OCP.BOPAlgo.BOPAlgo_Splitter()
parts = [result]
if len(parts) == 1:
    # merged_solid = cq.Compound(solids)
    
    merged_surface_compound = parts[0].toOCC()
else:
    for solid in parts:
        # checks if solid is a compound as .val() is not needed for compounds
        if isinstance(
            solid, (cq.occ_impl.shapes.Compound, cq.occ_impl.shapes.Solid)
        ):
            bldr.AddArgument(solid.wrapped)
        else:
            bldr.AddArgument(solid.val().wrapped)

    bldr.SetNonDestructive(True)

    bldr.Perform()

    bldr.Images()

    merged_surface_compound = cq.Compound(bldr.Shape()).wrapped
import gmsh
topods = merged_surface_compound
gmsh.initialize()
gmsh.option.setNumber("General.Terminal", 1)
volumes = gmsh.model.occ.importShapesNativePointer(topods._address())
gmsh.model.occ.synchronize()
gmsh.option.setNumber("Mesh.Algorithm", 1)
gmsh.option.setNumber("Mesh.MeshSizeMin", 0.1)
gmsh.option.setNumber("Mesh.MeshSizeMax", 2)
gmsh.model.mesh.generate(2)
gmsh.write("gmsh_of_cadquery_compound_in_memory.msh")
```