### PR TITLE
conda-forge install instructions not ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ conda activate new_env
 
 Installs cad_to_dagmc and dependencies
 ```bash
-conda install -c conda-forge cad_to_dagmc
+conda install -c fusion-energy -c cadquery -c conda-forge cad_to_dagmc
 ```
+TODO move to conda-forge ~conda install -c conda-forge cad_to_dagmc~
 # Install (Mamba)
 
 Creates a new empty Conda environment and activate it
@@ -45,8 +46,9 @@ conda install -c conda-forge mamba
 
 Installs cad_to_dagmc and dependencies
 ```bash
-mamba install -c conda-forge cad_to_dagmc
+mamba install -c fusion-energy -c cadquery -c conda-forge cad_to_dagmc
 ```
+TODO move to conda-forge ~mamba install -c conda-forge cad_to_dagmc~
 
 # Install (Conda + pip)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This example uses Conda but Mamba could also be used.
 conda install -c conda-forge moab
 conda install -c conda-forge gmsh
 conda install -c conda-forge python-gmsh
+conda install -c conda-forge cadquery
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ TODO move to conda-forge ~mamba install -c conda-forge cad_to_dagmc~
 You will need to install some dependencies that are not available via PyPi.
 This example uses Conda but Mamba could also be used.
 ```bash
-conda install -c conda-forge cadquery=2.2.0 occt=7.7.0 moab gmsh python-gmsh
+conda install -c cadquery -c conda-forge cadquery=master moab gmsh python-gmsh
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ TODO move to conda-forge ~mamba install -c conda-forge cad_to_dagmc~
 You will need to install some dependencies that are not available via PyPi.
 This example uses Conda but Mamba could also be used.
 ```bash
-conda install -c conda-forge moab
-conda install -c conda-forge gmsh
-conda install -c conda-forge python-gmsh
-conda install -c conda-forge cadquery
+conda install -c conda-forge cadquery=2.2.0 occt=7.7.0 moab gmsh python-gmsh
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```


### PR DESCRIPTION
As the install is not yet working on conda forge then the instructions should have the currently available method of installing