### PR TITLE
removing old conda install package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,38 +18,6 @@ is intended to convert STP files or [CadQuery](https://cadquery.readthedocs.io) 
 One unique feature of this package is the ability to combine STP files with CadQuery objects.
 This allows for the addition of parametric geometry to static geometry.
 
-# Install (Conda)
-
-Creates a new empty Conda environment and activate it
-```bash
-conda create --name new_env python=3.9
-conda activate new_env
-```
-
-Installs cad_to_dagmc and dependencies
-```bash
-conda install -c fusion-energy -c cadquery -c conda-forge cad_to_dagmc
-```
-TODO move to conda-forge ~conda install -c conda-forge cad_to_dagmc~
-# Install (Mamba)
-
-Creates a new empty Conda environment and activate it
-```bash
-conda create --name new_env python=3.9
-conda activate new_env
-```
-
-Installs Mamba
-```bash
-conda install -c conda-forge mamba
-```
-
-Installs cad_to_dagmc and dependencies
-```bash
-mamba install -c fusion-energy -c cadquery -c conda-forge cad_to_dagmc
-```
-TODO move to conda-forge ~mamba install -c conda-forge cad_to_dagmc~
-
 # Install (Conda + pip)
 
 You will need to install some dependencies that are not available via PyPi.


### PR DESCRIPTION
the fusion-energy conda package is now depreciated 