### PR TITLE
simpler install possible as CadQuery uses OCP 7.7.1

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -35,10 +35,9 @@ jobs:
           apt-get --allow-releaseinfo-change update
           apt-get update -y
           apt-get upgrade -y
-          apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev
-          apt-get install -y libpangocairo-1.0-0
-          conda install -c conda-forge mamba -y
-          mamba install -c conda-forge moab gmsh python-gmsh cadquery=master -y
+          apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
+          conda install -y -c conda-forge mamba
+          mamba install -y -c cadquery -c conda-forge moab gmsh python-gmsh cadquery=master
 
       - name: install package
         run: |

--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -38,8 +38,7 @@ jobs:
           apt-get install -y libgl1-mesa-glx libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev
           apt-get install -y libpangocairo-1.0-0
           conda install -c conda-forge mamba -y
-          mamba install -c conda-forge moab multimethod typish ezdxf nptyping nlopt casadi gmsh python-gmsh ocp>=7.7.1 -y
-          mamba install -c cadquery -c conda-forge cadquery=master --no-deps -y
+          mamba install -c conda-forge moab gmsh python-gmsh cadquery=master -y
 
       - name: install package
         run: |

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 
 [![Upload Python Package](https://github.com/fusion-energy/cad_to_dagmc/actions/workflows/python-publish.yml/badge.svg)](https://github.com/fusion-energy/cad_to_dagmc/actions/workflows/python-publish.yml)
 
-
 [![PyPI](https://img.shields.io/pypi/v/cad_to_dagmc?color=brightgreen&label=pypi&logo=grebrightgreenen&logoColor=green)](https://pypi.org/project/cad_to_dagmc/)
 
 ___
 
-A minimal package that uses CadQuery functionality to convert Cad geometry to [DAGMC](https://github.com/svalinn/DAGMC/) h5m files
+A minimal package that uses CadQuery functionality to convert CAD geometry to [DAGMC](https://github.com/svalinn/DAGMC/) h5m files
 
 This particular method of producing DAGMC compatible h5m files from CAD geometry
 is intended to convert STP files or [CadQuery](https://cadquery.readthedocs.io) objects to h5m file.
@@ -18,9 +17,47 @@ is intended to convert STP files or [CadQuery](https://cadquery.readthedocs.io) 
 One unique feature of this package is the ability to combine STP files with CadQuery objects.
 This allows for the addition of parametric geometry to static geometry.
 
-# Installation
+The resulting DAGMC geometry can then be used for simulations in [OpenMC](https://github.com/openmc-dev/openmc/) or [other supported codes](https://svalinn.github.io/DAGMC/).
 
-In principle, any Conda distribution will work. 
+# Installation prerequisite
+
+In principle, any Conda/Mamba distribution will work. A few Conda/Mamba options are:
+- [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge)
+- [Miniforge](https://github.com/conda-forge/miniforge#miniforge-pypy3)
+- [Anaconda](https://www.anaconda.com/download)
+- [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+
+
+# Install using Mamba and pip
+
+This example assumes you have installed the MambaForge option or separately
+installed Mamba with ```conda install -c conda-forge mamba -y```
+
+Create a new conda environment, I've chosen Python 3.9 here but new versions are
+also supported.
+```bash
+mamba create --name new_env python=3.9 -y
+```
+
+Activate the environment
+```bash
+mamba activate new_env
+```
+
+Install the dependencies
+```bash
+mamba install -c conda-forge moab gmsh python-gmsh cadquery=master -y
+```
+
+Then you can install the cad_to_dagmc package with ```pip```
+```bash
+pip install cad_to_dagmc
+```
+
+You may also want to install OpenMC with DAGMC to make use of the h5m geometry files produced in simulations. However you could also use other supported particle transport codes such as MCNP, FLUKA and others [link to DAGMC documentation](https://svalinn.github.io/DAGMC/).You can run ```conda install -c conda-forge openmc``` however this more specific command makes sure the latest version of OpenMC which contains DAGMC is chosen by conda / mamba
+```bash
+mamba install -c conda-forge -y "openmc=0.13.3=dagmc*nompi*"
+```
 
 
 # Install using Conda and pip
@@ -39,8 +76,7 @@ conda activate new_env
 
 Install the dependencies
 ```bash
-conda install -c conda-forge moab multimethod typish ezdxf nptyping nlopt casadi gmsh python-gmsh ocp>=7.7.1 -y
-conda install -c cadquery -c conda-forge cadquery=master --no-deps -y
+conda install -c conda-forge moab gmsh python-gmsh cadquery=master -y
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```
@@ -54,37 +90,6 @@ conda install -c conda-forge -y "openmc=0.13.3=dagmc*nompi*"
 ```
 
 
-# Install using Mamba and pip
-
-This example uses Mamba to install some dependencies that are not available via PyPi.
-
-Create a new conda environment, I've chosen Python 3.9 here but new versions are
-also supported.
-```bash
-conda create --name new_env python=3.9 -y
-```
-
-Activate the environment
-```bash
-mamba activate new_env
-```
-
-Install the dependencies
-```bash
-conda install -c conda-forge mamba -y
-mamba install -c conda-forge moab multimethod typish ezdxf nptyping nlopt casadi gmsh python-gmsh ocp>=7.7.1 -y
-mamba install -c cadquery -c conda-forge cadquery=master --no-deps -y
-```
-
-Then you can install the cad_to_dagmc package with ```pip```
-```bash
-pip install cad_to_dagmc
-```
-
-You may also want to install OpenMC with DAGMC to make use of the h5m geometry files produced in simulations. However you could also use other supported particle transport codes such as MCNP, FLUKA and others [link to DAGMC documentation](https://svalinn.github.io/DAGMC/).You can run ```conda install -c conda-forge openmc``` however this more specific command makes sure the latest version of OpenMC which contains DAGMC is chosen by conda / mamba
-```bash
-mamba install -c conda-forge -y "openmc=0.13.3=dagmc*nompi*"
-```
 
 # Usage - creation of DAGMC h5m files
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ mamba activate new_env
 
 Install the dependencies
 ```bash
-mamba install -c conda-forge moab gmsh python-gmsh cadquery=master -y
+mamba install -c cadquery -c conda-forge moab gmsh python-gmsh cadquery=master -y
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```
@@ -76,7 +76,7 @@ conda activate new_env
 
 Install the dependencies
 ```bash
-conda install -c conda-forge moab gmsh python-gmsh cadquery=master -y
+conda install -c cadquery -c conda-forge moab gmsh python-gmsh cadquery=master -y
 ```
 
 Then you can install the cad_to_dagmc package with ```pip```


### PR DESCRIPTION
If [this](https://github.com/CadQuery/cadquery/pull/1343) Cadquery PR gets merged in then we can simplify the install process for this package

