### PR TITLE
rely on cadquery to bring in cadquery-ocp as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 dependencies = [
     "trimesh",
     "networkx",
-    "cadquery-ocp>=7.7.2",
     "cadquery>=2.4.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
this will help with the conda package creation as conda build based on the pypi source is complaining that package name cadquery-ocp is not installed