### PR TITLE
Faster unstrucutred mesh file production by writing vtk file

### DIFF
--- a/examples/unstrucutred_volume_mesh/curved_cadquery_object_to_dagmc_volume_mesh.py
+++ b/examples/unstrucutred_volume_mesh/curved_cadquery_object_to_dagmc_volume_mesh.py
@@ -59,4 +59,4 @@ my_model = CadToDagmc()
 my_model.add_cadquery_object(result, material_tags=["mat1"])
 my_model.add_cadquery_object(result2, material_tags=["mat2"])
 
-my_model.export_unstructured_mesh_file(filename="umesh.h5m", max_mesh_size=1, min_mesh_size=0.1)
+my_model.export_unstructured_mesh_file(filename="umesh.vtk", max_mesh_size=1, min_mesh_size=0.1)

--- a/examples/unstrucutred_volume_mesh/simulate_unstrucutred_volume_mesh_with_openmc.py
+++ b/examples/unstrucutred_volume_mesh/simulate_unstrucutred_volume_mesh_with_openmc.py
@@ -1,4 +1,4 @@
-# script assumes that "umesh.h5m" has been created by
+# script assumes that "umesh.vtk" has been created by
 # curved_cadquery_object_to_dagmc_volume_mesh.py has been
 
 import openmc
@@ -14,7 +14,7 @@ with open("cross_sections.xml", "w") as file:
     )
 openmc.config["cross_sections"] = "cross_sections.xml"
 
-umesh = openmc.UnstructuredMesh("umesh.h5m", library="moab")
+umesh = openmc.UnstructuredMesh("umesh.vtk", library="moab")
 mesh_filter = openmc.MeshFilter(umesh)
 tally = openmc.Tally(name="unstrucutred_mesh_tally")
 tally.filters = [mesh_filter]

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import cadquery as cq
 import gmsh
 import numpy as np
-from cadquery import importers, exporters
+from cadquery import importers
 from pymoab import core, types
 import tempfile
 
@@ -493,7 +494,7 @@ class CadToDagmc:
     ):
         """
         Exports an unstructured mesh file in VTK format for use with openmc.UnstructuredMesh.
-        Compatible with the MOAB unstrucutred mesh library. Example useage
+        Compatible with the MOAB unstructured mesh library. Example useage
         openmc.UnstructuredMesh(filename="umesh.vtk", library="moab")
 
         Parameters:
@@ -523,6 +524,9 @@ class CadToDagmc:
             gmsh : gmsh
                 The gmsh object after finalizing the mesh.
         """
+
+        if Path(filename).suffix != ".vtk":
+            raise ValueError("Unstructured mesh filename must have a .vtk extension")
 
         assembly = cq.Assembly()
         for part in self.parts:


### PR DESCRIPTION
currently we write a vtk file, read the vtk file and then write h5 file. The h5 is used in OpenMC.unstructuredmesh. 

However we can use the vtk file directly and save some time