### PR TITLE
Remove version pin for numpy by updating to latest cq version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "trimesh",
     "networkx",
     "cadquery>=2.5.2",
-    "ezdxf>=1.3.0",
     "numpy",
     "gmsh"
 ]


### PR DESCRIPTION
just an update to use cq 2.5.2 which means we can also remove the pin on the numpy version :tada: 