### PR TITLE
added example using assembly-mesh-plugin

### DIFF
--- a/.github/workflows/ci_with_conda_install.yml
+++ b/.github/workflows/ci_with_conda_install.yml
@@ -65,6 +65,7 @@ jobs:
           python examples/surface_mesh/cadquery_text.py
           python examples/surface_mesh/curved_cadquery_object_to_dagmc_surface_mesh.py
           python examples/surface_mesh/from_gmsh_mesh_file.py
+          python examples/surface_mesh/from_gmsh_object_with_tag.py
           python examples/surface_mesh/multiple_cadquery_objects.py
           python examples/surface_mesh/multiple_stp_files.py
           python examples/surface_mesh/single_cadquery_object.py

--- a/.github/workflows/ci_with_pip_install.yml
+++ b/.github/workflows/ci_with_pip_install.yml
@@ -56,6 +56,7 @@ jobs:
           python examples/surface_mesh/single_cadquery_object.py
           python examples/surface_mesh/single_stp_file.py
           python examples/surface_mesh/from_gmsh_mesh_file.py
+          python examples/surface_mesh/from_gmsh_object_with_tag.py
           python examples/unstrucutred_volume_mesh/curved_cadquery_object_to_dagmc_volume_mesh.py
           python examples/unstrucutred_volume_mesh/simulate_unstrucutred_volume_mesh_with_openmc.py
           python examples/unstrucutred_volume_mesh/different_resolution_meshes.py

--- a/examples/surface_mesh/from_gmsh_mesh_file.py
+++ b/examples/surface_mesh/from_gmsh_mesh_file.py
@@ -1,10 +1,12 @@
 # this file makes a GMESH mesh file from a Step file
 # then loads up the GMESH file and converts it to a DAGMC file
 
-
-# making the GMESH file
 from cad_to_dagmc import CadToDagmc
 import cadquery as cq
+import cad_to_dagmc
+import openmc
+
+# making the gmsh file just so we have one for the example
 
 result1 = cq.Workplane("XY").box(10.0, 10.0, 5.0)
 result2 = cq.Workplane("XY").moveTo(10, 0).box(10.0, 10.0, 5.0)
@@ -17,7 +19,6 @@ geometry = CadToDagmc()
 geometry.add_stp_file("two_connected_cubes.stp")
 geometry.export_gmsh_mesh_file(filename="example_gmsh_mesh.msh")
 
-import cad_to_dagmc
 
 # converting the mesh file to a DAGMC file
 
@@ -27,8 +28,6 @@ cad_to_dagmc.export_dagmc_h5m_file(
     dagmc_filename="dagmc.h5m",
 )
 
-# making use of the DAGMC file in OpenMC
-import openmc
 
 openmc.config["cross_sections"] = "cross_sections.xml"
 

--- a/examples/surface_mesh/from_gmsh_object_with_tag.py
+++ b/examples/surface_mesh/from_gmsh_object_with_tag.py
@@ -1,0 +1,26 @@
+import cadquery as cq
+import cad_to_dagmc
+import gmsh
+import assembly_mesh_plugin.plugin
+
+box_shape1 = cq.Workplane("XY").box(50, 50, 50)
+box_shape2 = cq.Workplane("XY").moveTo(0, 50).box(50, 50, 100)
+
+assembly = cq.Assembly()
+assembly.add(box_shape1, name="first_material")
+assembly.add(box_shape2, name="second_material")
+
+# getTaggedGmsh initializes gmsh and creates a mesh object ready for meshing
+assembly.getTaggedGmsh()
+# Here you can set the mesh parameters
+# In this case, we set the minimum and maximum mesh size
+# but you can set any other Gmsh parameters
+# Remember that the gmsh has physical groups if you want to use them when meshing
+gmsh.option.setNumber("Mesh.MeshSizeMax", 4.2)
+gmsh.model.mesh.generate(2)  # for DAGMC surface mesh we just need a 2D surface mesh
+
+cad_to_dagmc.export_gmsh_object_to_dagmc_h5m_file(filename="dagmc_from_gmsh_object.h5m")
+
+# finalize the GMSH API after using export_gmsh_object_to_dagmc_h5m_file
+# and getTaggedGmsh as these both need access to the GMSH object.
+gmsh.finalize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ write_to = "src/_version.py"
 tests = [
     "pytest",
     "vtk",
-    "assembly-mesh-plugin @ git+https://github.com/CadQuery/assembly-mesh-plugin",
+    "assembly-mesh-plugin",
     "pydagmc @ git+https://github.com/shimwell/pydagmc@packaging-update",
 ]
 


### PR DESCRIPTION
This PR adds an new example that makes use of the https://github.com/CadQuery/assembly-mesh-plugin package to make a dagmc geometry

1. first the example makes a cadquery assembly (where parts have names)
2. the assembly-mesh-plugin is then used to make a tagged gmsh object (assembly names become the tags)
3. the mesh parameters are then set by the script and mesh generated
4. the mesh contains physical groups that can be used as material tag
5. the gmsh mesh is then written to a dagmc file.

- This example is more flexible than other workflows as one can set mesh parameters directly
- Fairly concise as the assembly names are reused as material tags, no need to redefine.
- Fairly fast as objects are passed in memory instead of writing to file and reading.

Just tagging you so that you can see your assembly-mesh-plugin is being used over here
@jmwright