### PR TITLE
Fix gmsh session leak when exporting only a surface mesh (#187)

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -759,6 +759,14 @@ def get_volumes(gmsh, assembly, method="file", scale_factor=1.0):
 
 
 def init_gmsh():
+    # gmsh is a global singleton. If a previous session was left initialized
+    # (for example by an export that errored part way through, or an earlier
+    # call that did not finalize) then adding a new model here would leave the
+    # stale models from that session alive, leaking memory and growing the
+    # session on every call (see issue #187). Finalize any pre-existing
+    # session first so we always start from a clean, single-model state.
+    if gmsh.isInitialized():
+        gmsh.finalize()
     gmsh.initialize()
     gmsh.option.setNumber("General.Terminal", 1)
     gmsh.model.add(f"made_with_cad_to_dagmc_package_{__version__}")
@@ -1786,150 +1794,162 @@ class CadToDagmc:
             msg = f"Number of volumes {len(original_ids)} is not equal to number of material tags {len(self.material_tags)}"
             raise ValueError(msg)
 
-        # Use the CadQuery direct mesh plugin
-        if meshing_backend == "cadquery":
-            import cadquery_direct_mesh_plugin
-            # Mesh the assembly using CadQuery's direct-mesh plugin
-            cq_mesh = assembly.toMesh(
-                imprint=imprint,
-                tolerance=tolerance,
-                angular_tolerance=angular_tolerance,
-                scale_factor=scale_factor,
-            )
-
-            # Fix the material tag order for imprinted assemblies
-            if cq_mesh["imprinted_assembly"] is not None:
-                imprinted_solids_with_org_id = cq_mesh[
-                    "imprinted_solids_with_orginal_ids"
-                ]
-
-                scrambled_ids = get_ids_from_imprinted_assembly(
-                    imprinted_solids_with_org_id
-                )
-
-                material_tags_in_brep_order = order_material_ids_by_brep_order(
-                    original_ids, scrambled_ids, self.material_tags
-                )
-            else:
-                material_tags_in_brep_order = self.material_tags
-
-            check_material_tags(material_tags_in_brep_order, self.parts)
-
-            # Extract the mesh information to allow export to h5m from the direct-mesh result
-            vertices = cq_mesh["vertices"]
-            triangles_by_solid_by_face = cq_mesh["solid_face_triangle_vertex_map"]
-        # Use gmsh
-        elif meshing_backend == "gmsh":
-            # If assembly is not to be imprinted, pass through the assembly as-is
-            if imprint:
-                print("Imprinting assembly for mesh generation")
-                imprinted_assembly, imprinted_solids_with_org_id = (
-                    cq.occ_impl.assembly.imprint(assembly)
-                )
-
-                scrambled_ids = get_ids_from_imprinted_assembly(
-                    imprinted_solids_with_org_id
-                )
-
-                material_tags_in_brep_order = order_material_ids_by_brep_order(
-                    original_ids, scrambled_ids, self.material_tags
-                )
-
-            else:
-                material_tags_in_brep_order = self.material_tags
-                imprinted_assembly = assembly
-
-            check_material_tags(material_tags_in_brep_order, self.parts)
-
-            # Start generating the mesh
-            gmsh = init_gmsh()
-
-            gmsh, volumes = get_volumes(
-                gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
-            )
-
-            # Resolve any material tag strings in set_size to volume IDs
-            resolved_set_size = None
-            if set_size:
-                resolved_set_size = resolve_set_size(
-                    set_size, volumes, material_tags_in_brep_order
-                )
-
-            gmsh = set_sizes_for_mesh(
-                gmsh=gmsh,
-                min_mesh_size=min_mesh_size,
-                max_mesh_size=max_mesh_size,
-                mesh_algorithm=mesh_algorithm,
-                set_size=resolved_set_size,
-                original_set_size=set_size,
-                threads=threads,
-            )
-
-            gmsh.model.mesh.generate(2)
-
-            vertices, triangles_by_solid_by_face = mesh_to_vertices_and_triangles(
-                dims_and_vol_ids=volumes
-            )
-
-        elif meshing_backend == "cad-to-dagmc-mesher":
-            tet_volumes_arg = kwargs.get("tet_volumes", kwargs.get("unstructured_volumes"))
-            target_edge_length = kwargs.get("target_edge_length")
-
-            vertices, triangles_by_solid_by_face, material_tags_in_brep_order = (
-                _mesh_with_cad_to_dagmc_mesher(
-                    assembly=assembly,
-                    material_tags=self.material_tags,
+        # The gmsh backend opens a gmsh session (gmsh is a global singleton).
+        # Wrap the whole meshing and export in try/finally so the session is
+        # always finalized for the gmsh backend - on every return path and even
+        # if meshing raises part way through. Without this, repeated calls
+        # accumulate gmsh models in the session (see issue #187). The
+        # isInitialized() guard keeps the finally safe if an error occurs before
+        # init_gmsh() runs, and scoping to the gmsh backend avoids finalizing a
+        # session the caller may own when using a non-gmsh backend.
+        try:
+            # Use the CadQuery direct mesh plugin
+            if meshing_backend == "cadquery":
+                import cadquery_direct_mesh_plugin
+                # Mesh the assembly using CadQuery's direct-mesh plugin
+                cq_mesh = assembly.toMesh(
+                    imprint=imprint,
                     tolerance=tolerance,
                     angular_tolerance=angular_tolerance,
-                    tet_volumes=tet_volumes_arg,
-                    target_edge_length=target_edge_length,
-                    imprint=imprint,
+                    scale_factor=scale_factor,
                 )
+
+                # Fix the material tag order for imprinted assemblies
+                if cq_mesh["imprinted_assembly"] is not None:
+                    imprinted_solids_with_org_id = cq_mesh[
+                        "imprinted_solids_with_orginal_ids"
+                    ]
+
+                    scrambled_ids = get_ids_from_imprinted_assembly(
+                        imprinted_solids_with_org_id
+                    )
+
+                    material_tags_in_brep_order = order_material_ids_by_brep_order(
+                        original_ids, scrambled_ids, self.material_tags
+                    )
+                else:
+                    material_tags_in_brep_order = self.material_tags
+
+                check_material_tags(material_tags_in_brep_order, self.parts)
+
+                # Extract the mesh information to allow export to h5m from the direct-mesh result
+                vertices = cq_mesh["vertices"]
+                triangles_by_solid_by_face = cq_mesh["solid_face_triangle_vertex_map"]
+            # Use gmsh
+            elif meshing_backend == "gmsh":
+                # If assembly is not to be imprinted, pass through the assembly as-is
+                if imprint:
+                    print("Imprinting assembly for mesh generation")
+                    imprinted_assembly, imprinted_solids_with_org_id = (
+                        cq.occ_impl.assembly.imprint(assembly)
+                    )
+
+                    scrambled_ids = get_ids_from_imprinted_assembly(
+                        imprinted_solids_with_org_id
+                    )
+
+                    material_tags_in_brep_order = order_material_ids_by_brep_order(
+                        original_ids, scrambled_ids, self.material_tags
+                    )
+
+                else:
+                    material_tags_in_brep_order = self.material_tags
+                    imprinted_assembly = assembly
+
+                check_material_tags(material_tags_in_brep_order, self.parts)
+
+                # Start generating the mesh
+                gmsh = init_gmsh()
+
+                gmsh, volumes = get_volumes(
+                    gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
+                )
+
+                # Resolve any material tag strings in set_size to volume IDs
+                resolved_set_size = None
+                if set_size:
+                    resolved_set_size = resolve_set_size(
+                        set_size, volumes, material_tags_in_brep_order
+                    )
+
+                gmsh = set_sizes_for_mesh(
+                    gmsh=gmsh,
+                    min_mesh_size=min_mesh_size,
+                    max_mesh_size=max_mesh_size,
+                    mesh_algorithm=mesh_algorithm,
+                    set_size=resolved_set_size,
+                    original_set_size=set_size,
+                    threads=threads,
+                )
+
+                gmsh.model.mesh.generate(2)
+
+                vertices, triangles_by_solid_by_face = mesh_to_vertices_and_triangles(
+                    dims_and_vol_ids=volumes
+                )
+
+            elif meshing_backend == "cad-to-dagmc-mesher":
+                tet_volumes_arg = kwargs.get("tet_volumes", kwargs.get("unstructured_volumes"))
+                target_edge_length = kwargs.get("target_edge_length")
+
+                vertices, triangles_by_solid_by_face, material_tags_in_brep_order = (
+                    _mesh_with_cad_to_dagmc_mesher(
+                        assembly=assembly,
+                        material_tags=self.material_tags,
+                        tolerance=tolerance,
+                        angular_tolerance=angular_tolerance,
+                        tet_volumes=tet_volumes_arg,
+                        target_edge_length=target_edge_length,
+                        imprint=imprint,
+                    )
+                )
+
+            else:
+                raise ValueError(
+                    f'meshing_backend {meshing_backend} not supported. '
+                    'Available options are "cadquery", "gmsh", or "cad-to-dagmc-mesher"'
+                )
+
+            dagmc_filename = vertices_to_h5m(
+                vertices=vertices,
+                triangles_by_solid_by_face=triangles_by_solid_by_face,
+                material_tags=material_tags_in_brep_order,
+                h5m_filename=filename,
+                implicit_complement_material_tag=implicit_complement_material_tag,
+                method=h5m_backend,
             )
 
-        else:
-            raise ValueError(
-                f'meshing_backend {meshing_backend} not supported. '
-                'Available options are "cadquery", "gmsh", or "cad-to-dagmc-mesher"'
-            )
+            if meshing_backend == "gmsh" and unstructured_volumes:
+                # Resolve any material tag strings to volume IDs
+                unstructured_volumes = resolve_unstructured_volumes(
+                    unstructured_volumes, volumes, material_tags_in_brep_order
+                )
+                # remove all the unused occ volumes, this prevents them being meshed
+                for volume_dim, volume_id in volumes:
+                    if volume_id not in unstructured_volumes:
+                        gmsh.model.occ.remove(
+                            [(volume_dim, volume_id)], recursive=True
+                        )
+                gmsh.option.setNumber("Mesh.SaveAll", 1)
+                gmsh.model.occ.synchronize()
 
-        dagmc_filename = vertices_to_h5m(
-            vertices=vertices,
-            triangles_by_solid_by_face=triangles_by_solid_by_face,
-            material_tags=material_tags_in_brep_order,
-            h5m_filename=filename,
-            implicit_complement_material_tag=implicit_complement_material_tag,
-            method=h5m_backend,
-        )
+                # removes all the 2D groups so that 2D faces are not included in the vtk file
+                all_2d_groups = gmsh.model.getPhysicalGroups(2)
+                for entry in all_2d_groups:
+                    gmsh.model.removePhysicalGroups([entry])
 
-        if unstructured_volumes:
-            # Resolve any material tag strings to volume IDs
-            unstructured_volumes = resolve_unstructured_volumes(
-                unstructured_volumes, volumes, material_tags_in_brep_order
-            )
-            # remove all the unused occ volumes, this prevents them being meshed
-            for volume_dim, volume_id in volumes:
-                if volume_id not in unstructured_volumes:
-                    gmsh.model.occ.remove([(volume_dim, volume_id)], recursive=True)
-            gmsh.option.setNumber("Mesh.SaveAll", 1)
-            gmsh.model.occ.synchronize()
+                gmsh.model.mesh.generate(3)
+                gmsh.option.setNumber(
+                    "Mesh.SaveElementTagType", 3
+                )  # Save only volume elements
+                gmsh.write(umesh_filename)
 
-            # removes all the 2D groups so that 2D faces are not included in the vtk file
-            all_2d_groups = gmsh.model.getPhysicalGroups(2)
-            for entry in all_2d_groups:
-                gmsh.model.removePhysicalGroups([entry])
+                return dagmc_filename, umesh_filename
 
-            gmsh.model.mesh.generate(3)
-            gmsh.option.setNumber(
-                "Mesh.SaveElementTagType", 3
-            )  # Save only volume elements
-            gmsh.write(umesh_filename)
-
-            gmsh.finalize()
-
-            return dagmc_filename, umesh_filename
-        else:
             return dagmc_filename
+        finally:
+            if meshing_backend == "gmsh" and gmsh.isInitialized():
+                gmsh.finalize()
 
 
 def _mesh_with_cad_to_dagmc_mesher(

--- a/tests/test_gmsh_session_cleanup.py
+++ b/tests/test_gmsh_session_cleanup.py
@@ -1,0 +1,101 @@
+"""Regression tests for issue #187.
+
+CadToDagmc used the gmsh global singleton without finalizing it on the
+surface-mesh export path, so repeated calls accumulated gmsh models in the
+session. These tests assert that the gmsh session is properly cleaned up.
+"""
+
+import cadquery as cq
+import gmsh
+import pytest
+
+from cad_to_dagmc import CadToDagmc
+from cad_to_dagmc.core import init_gmsh
+
+
+def _sphere_model(radius):
+    model = CadToDagmc()
+    model.add_cadquery_object(
+        cadquery_object=cq.Workplane().sphere(radius),
+        material_tags=["mat_steel"],
+    )
+    return model
+
+
+def test_gmsh_surface_export_does_not_leak_session(tmp_path):
+    """Repeatedly exporting a surface mesh with the gmsh backend must not
+    leave the gmsh session initialized nor accumulate gmsh models."""
+    for i in range(4):
+        model = _sphere_model(5.0 + i)
+        model.export_dagmc_h5m_file(
+            filename=str(tmp_path / f"geom_{i}.h5m"),
+            min_mesh_size=2.0,
+            max_mesh_size=10.0,
+            mesh_algorithm=1,
+        )
+        # The export must finalize the gmsh session it opened, so nothing is
+        # left alive between calls.
+        assert not gmsh.isInitialized()
+
+
+def test_gmsh_unstructured_export_does_not_leak_session(tmp_path):
+    """The unstructured-volume export path must also finalize gmsh."""
+    model = _sphere_model(5.0)
+    model.export_dagmc_h5m_file(
+        filename=str(tmp_path / "geom.h5m"),
+        umesh_filename=str(tmp_path / "umesh.vtk"),
+        min_mesh_size=2.0,
+        max_mesh_size=10.0,
+        unstructured_volumes=[1],
+    )
+    assert not gmsh.isInitialized()
+
+
+def test_gmsh_export_finalizes_on_meshing_error(tmp_path, monkeypatch):
+    """If gmsh meshing raises part way through, the session must still be
+    finalized within the same call (not left open until the next init_gmsh)."""
+    model = _sphere_model(5.0)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated meshing failure")
+
+    # Make 2D surface mesh generation fail after the gmsh session has been
+    # initialized by init_gmsh().
+    monkeypatch.setattr("gmsh.model.mesh.generate", boom)
+
+    with pytest.raises(RuntimeError, match="simulated meshing failure"):
+        model.export_dagmc_h5m_file(
+            filename=str(tmp_path / "geom.h5m"),
+            min_mesh_size=2.0,
+            max_mesh_size=10.0,
+        )
+
+    # The failed export must not leave the gmsh session initialized.
+    assert not gmsh.isInitialized()
+
+
+def test_init_gmsh_clears_leaked_session():
+    """init_gmsh must start from a clean session even if gmsh was already
+    initialized with stale models (self-healing against leaked sessions)."""
+    # Simulate a leaked session containing multiple stale models.
+    if gmsh.isInitialized():
+        gmsh.finalize()
+    gmsh.initialize()
+    gmsh.model.add("stale_model_a")
+    gmsh.model.add("stale_model_b")
+    assert "stale_model_a" in gmsh.model.list()
+
+    try:
+        init_gmsh()
+        models = gmsh.model.list()
+        # The stale models from the leaked session must have been cleared.
+        assert "stale_model_a" not in models
+        assert "stale_model_b" not in models
+        # A fresh session holds only gmsh's default unnamed model plus the
+        # single model init_gmsh adds (which becomes the current one). The
+        # count must not have grown by piling onto the leaked session.
+        assert len(models) == 2
+        assert gmsh.model.getCurrent().startswith("made_with_cad_to_dagmc_package")
+    finally:
+        if gmsh.isInitialized():
+            gmsh.finalize()


### PR DESCRIPTION
Fixes #187.

## Problem

`gmsh` is a global singleton. `CadToDagmc.export_dagmc_h5m_file()` with the gmsh backend only called `gmsh.finalize()` on the `unstructured_volumes` path — the plain surface-mesh path returned without finalizing, leaving the session open. Since `init_gmsh()` adds a new model on every call, repeated surface-mesh exports accumulated gmsh models in the session.

Reproduction from the issue (gmsh model count growing across calls):

```
build 0: models alive in gmsh session = 2
build 1: models alive in gmsh session = 3
build 2: models alive in gmsh session = 4
build 3: models alive in gmsh session = 5
```

After this change the same script reports `0` after every build.

## Fix

- `init_gmsh()` now finalizes any pre-existing session before re-initializing, so it always starts from a clean single-model state and self-heals a session leaked by an earlier call.
- `export_dagmc_h5m_file()` wraps the whole gmsh meshing and export in `try/finally`, so the session is finalized on every return path (surface and unstructured) and even if meshing raises part way through. Finalization is scoped to the gmsh backend so a session the caller owns is left untouched when using the `cadquery` and `cad-to-dagmc-mesher` backends.

The functional change is small; most of the diff is re-indentation from the `try` wrapper.

## Tests

Adds `tests/test_gmsh_session_cleanup.py` with four regression tests:

- surface export does not leak the session (the reported symptom)
- unstructured export does not leak the session
- a mid-mesh exception still finalizes the session within the same call
- `init_gmsh()` clears a leaked session with stale models

The two bug-catching tests and the exception test were confirmed to fail on the pre-fix code and pass after the fix. All existing gmsh and cadquery backend tests continue to pass; no new failures introduced.