### PR TITLE
Harden gmsh session finalization across the gmsh export methods

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1458,56 +1458,65 @@ class CadToDagmc:
         else:
             imprinted_assembly = assembly
 
-        gmsh = init_gmsh()
+        # gmsh is a global singleton; finalize the session on every exit path
+        # (including a mid-mesh exception) so repeated calls don't accumulate
+        # models. gmsh_session_started is only set once init_gmsh() has bound
+        # the local gmsh name, keeping the finally safe if init_gmsh() itself
+        # raises. See issue #187.
+        gmsh_session_started = False
+        try:
+            gmsh = init_gmsh()
+            gmsh_session_started = True
 
-        gmsh, volumes_in_model = get_volumes(
-            gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
-        )
-
-        # Resolve any material tag strings in set_size to volume IDs
-        resolved_set_size = None
-        if set_size:
-            resolved_set_size = resolve_set_size(
-                set_size, volumes_in_model, self.material_tags
+            gmsh, volumes_in_model = get_volumes(
+                gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
             )
 
-        gmsh = set_sizes_for_mesh(
-            gmsh=gmsh,
-            min_mesh_size=min_mesh_size,
-            max_mesh_size=max_mesh_size,
-            mesh_algorithm=mesh_algorithm,
-            set_size=resolved_set_size,
-            original_set_size=set_size,
-            threads=threads,
-        )
+            # Resolve any material tag strings in set_size to volume IDs
+            resolved_set_size = None
+            if set_size:
+                resolved_set_size = resolve_set_size(
+                    set_size, volumes_in_model, self.material_tags
+                )
 
-        if volumes:
-            for volume_id in volumes_in_model:
-                if volume_id[1] not in volumes:
-                    gmsh.model.occ.remove([volume_id], recursive=True)
-            gmsh.option.setNumber("Mesh.SaveAll", 1)
-            gmsh.model.occ.synchronize()
-            # Clear the mesh
-            gmsh.model.mesh.clear()
-            gmsh.option.setNumber(
-                "Mesh.SaveElementTagType", 3
-            )  # Save only volume elements
+            gmsh = set_sizes_for_mesh(
+                gmsh=gmsh,
+                min_mesh_size=min_mesh_size,
+                max_mesh_size=max_mesh_size,
+                mesh_algorithm=mesh_algorithm,
+                set_size=resolved_set_size,
+                original_set_size=set_size,
+                threads=threads,
+            )
 
-        gmsh.model.mesh.generate(3)
+            if volumes:
+                for volume_id in volumes_in_model:
+                    if volume_id[1] not in volumes:
+                        gmsh.model.occ.remove([volume_id], recursive=True)
+                gmsh.option.setNumber("Mesh.SaveAll", 1)
+                gmsh.model.occ.synchronize()
+                # Clear the mesh
+                gmsh.model.mesh.clear()
+                gmsh.option.setNumber(
+                    "Mesh.SaveElementTagType", 3
+                )  # Save only volume elements
 
-        # makes the folder if it does not exist
-        if Path(filename).parent:
-            Path(filename).parent.mkdir(parents=True, exist_ok=True)
+            gmsh.model.mesh.generate(3)
 
-        # gmsh.write only accepts strings
-        if isinstance(filename, Path):
-            gmsh.write(str(filename))
-        else:
-            gmsh.write(filename)
+            # makes the folder if it does not exist
+            if Path(filename).parent:
+                Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
-        gmsh.finalize()
+            # gmsh.write only accepts strings
+            if isinstance(filename, Path):
+                gmsh.write(str(filename))
+            else:
+                gmsh.write(filename)
 
-        return filename
+            return filename
+        finally:
+            if gmsh_session_started and gmsh.isInitialized():
+                gmsh.finalize()
 
     def export_gmsh_mesh_file(
         self,
@@ -1564,44 +1573,53 @@ class CadToDagmc:
         else:
             imprinted_assembly = assembly
 
-        gmsh = init_gmsh()
+        # gmsh is a global singleton; finalize the session on every exit path
+        # (including a mid-mesh exception) so repeated calls don't accumulate
+        # models. gmsh_session_started is only set once init_gmsh() has bound
+        # the local gmsh name, keeping the finally safe if init_gmsh() itself
+        # raises. See issue #187.
+        gmsh_session_started = False
+        try:
+            gmsh = init_gmsh()
+            gmsh_session_started = True
 
-        gmsh, volumes = get_volumes(
-            gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
-        )
-
-        # Resolve any material tag strings in set_size to volume IDs
-        resolved_set_size = None
-        if set_size:
-            resolved_set_size = resolve_set_size(
-                set_size, volumes, self.material_tags
+            gmsh, volumes = get_volumes(
+                gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
             )
 
-        gmsh = set_sizes_for_mesh(
-            gmsh=gmsh,
-            min_mesh_size=min_mesh_size,
-            max_mesh_size=max_mesh_size,
-            mesh_algorithm=mesh_algorithm,
-            set_size=resolved_set_size,
-            original_set_size=set_size,
-            threads=threads,
-        )
+            # Resolve any material tag strings in set_size to volume IDs
+            resolved_set_size = None
+            if set_size:
+                resolved_set_size = resolve_set_size(
+                    set_size, volumes, self.material_tags
+                )
 
-        gmsh.model.mesh.generate(dimensions)
+            gmsh = set_sizes_for_mesh(
+                gmsh=gmsh,
+                min_mesh_size=min_mesh_size,
+                max_mesh_size=max_mesh_size,
+                mesh_algorithm=mesh_algorithm,
+                set_size=resolved_set_size,
+                original_set_size=set_size,
+                threads=threads,
+            )
 
-        # makes the folder if it does not exist
-        if Path(filename).parent:
-            Path(filename).parent.mkdir(parents=True, exist_ok=True)
+            gmsh.model.mesh.generate(dimensions)
 
-        # gmsh.write only accepts strings
-        if isinstance(filename, Path):
-            gmsh.write(str(filename))
-        else:
-            gmsh.write(filename)
+            # makes the folder if it does not exist
+            if Path(filename).parent:
+                Path(filename).parent.mkdir(parents=True, exist_ok=True)
 
-        print(f"written GMSH mesh file {filename}")
+            # gmsh.write only accepts strings
+            if isinstance(filename, Path):
+                gmsh.write(str(filename))
+            else:
+                gmsh.write(filename)
 
-        gmsh.finalize()
+            print(f"written GMSH mesh file {filename}")
+        finally:
+            if gmsh_session_started and gmsh.isInitialized():
+                gmsh.finalize()
 
     def export_dagmc_h5m_file(
         self,

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1796,12 +1796,13 @@ class CadToDagmc:
 
         # The gmsh backend opens a gmsh session (gmsh is a global singleton).
         # Wrap the whole meshing and export in try/finally so the session is
-        # always finalized for the gmsh backend - on every return path and even
-        # if meshing raises part way through. Without this, repeated calls
-        # accumulate gmsh models in the session (see issue #187). The
-        # isInitialized() guard keeps the finally safe if an error occurs before
-        # init_gmsh() runs, and scoping to the gmsh backend avoids finalizing a
-        # session the caller may own when using a non-gmsh backend.
+        # always finalized - on every return path and even if meshing raises
+        # part way through. Without this, repeated calls accumulate gmsh models
+        # in the session (see issue #187). gmsh_session_started is only set once
+        # init_gmsh() has run, so the finally never touches the (function-local)
+        # gmsh name before it is bound and never finalizes a session the caller
+        # may own when using a non-gmsh backend.
+        gmsh_session_started = False
         try:
             # Use the CadQuery direct mesh plugin
             if meshing_backend == "cadquery":
@@ -1860,6 +1861,7 @@ class CadToDagmc:
 
                 # Start generating the mesh
                 gmsh = init_gmsh()
+                gmsh_session_started = True
 
                 gmsh, volumes = get_volumes(
                     gmsh, imprinted_assembly, method=method, scale_factor=scale_factor
@@ -1948,7 +1950,7 @@ class CadToDagmc:
 
             return dagmc_filename
         finally:
-            if meshing_backend == "gmsh" and gmsh.isInitialized():
+            if gmsh_session_started and gmsh.isInitialized():
                 gmsh.finalize()
 
 

--- a/tests/test_gmsh_session_cleanup.py
+++ b/tests/test_gmsh_session_cleanup.py
@@ -74,6 +74,40 @@ def test_gmsh_export_finalizes_on_meshing_error(tmp_path, monkeypatch):
     assert not gmsh.isInitialized()
 
 
+def test_export_gmsh_mesh_file_finalizes_on_meshing_error(tmp_path, monkeypatch):
+    """export_gmsh_mesh_file must finalize the gmsh session even if meshing
+    raises part way through."""
+    model = _sphere_model(5.0)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated meshing failure")
+
+    monkeypatch.setattr("gmsh.model.mesh.generate", boom)
+
+    with pytest.raises(RuntimeError, match="simulated meshing failure"):
+        model.export_gmsh_mesh_file(filename=str(tmp_path / "mesh.msh"))
+
+    assert not gmsh.isInitialized()
+
+
+def test_export_unstructured_mesh_file_finalizes_on_meshing_error(
+    tmp_path, monkeypatch
+):
+    """export_unstructured_mesh_file must finalize the gmsh session even if
+    meshing raises part way through."""
+    model = _sphere_model(5.0)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated meshing failure")
+
+    monkeypatch.setattr("gmsh.model.mesh.generate", boom)
+
+    with pytest.raises(RuntimeError, match="simulated meshing failure"):
+        model.export_unstructured_mesh_file(filename=str(tmp_path / "umesh.vtk"))
+
+    assert not gmsh.isInitialized()
+
+
 def test_gmsh_export_propagates_error_raised_before_session_starts(
     tmp_path, monkeypatch
 ):

--- a/tests/test_gmsh_session_cleanup.py
+++ b/tests/test_gmsh_session_cleanup.py
@@ -74,6 +74,30 @@ def test_gmsh_export_finalizes_on_meshing_error(tmp_path, monkeypatch):
     assert not gmsh.isInitialized()
 
 
+def test_gmsh_export_propagates_error_raised_before_session_starts(
+    tmp_path, monkeypatch
+):
+    """If the gmsh path fails before init_gmsh() runs (e.g. imprinting fails),
+    the original error must propagate. The finally must not mask it with an
+    UnboundLocalError from touching the function-local gmsh name before it is
+    bound."""
+    model = _sphere_model(5.0)
+
+    def boom():
+        raise RuntimeError("failure before gmsh session starts")
+
+    # init_gmsh() is the first statement in the gmsh path that binds the local
+    # gmsh name; failing here leaves it unbound when the finally runs.
+    monkeypatch.setattr("cad_to_dagmc.core.init_gmsh", boom)
+
+    with pytest.raises(RuntimeError, match="failure before gmsh session starts"):
+        model.export_dagmc_h5m_file(
+            filename=str(tmp_path / "geom.h5m"),
+            min_mesh_size=2.0,
+            max_mesh_size=10.0,
+        )
+
+
 def test_init_gmsh_clears_leaked_session():
     """init_gmsh must start from a clean session even if gmsh was already
     initialized with stale models (self-healing against leaked sessions)."""


### PR DESCRIPTION
Follow-up to #188. Makes gmsh session finalization robust and consistent across all three gmsh-using export methods.

## Background

`gmsh` is a process-global singleton. #187/#188 made `export_dagmc_h5m_file()` finalize the session on every path via `try/finally`, and made `init_gmsh()` self-heal a leaked session on the next call. This PR closes two remaining rough edges.

## 1. Don't mask the original error when gmsh setup fails before `init_gmsh()`

The `try/finally` in `export_dagmc_h5m_file()` guarded on `meshing_backend == "gmsh"` and then called `gmsh.isInitialized()`. But `gmsh` is a function-local name only bound once `gmsh = init_gmsh()` runs. If the gmsh path raised before that (most realistically `cq...imprint()` on degenerate geometry — the first step, with `imprint=True` the default), the `finally` evaluated `gmsh.isInitialized()` on an unbound local and raised `UnboundLocalError`, masking the real exception.

Fix: track session creation with a `gmsh_session_started` flag set immediately after `init_gmsh()`, and gate the `finally` on it. The flag is only `True` once `gmsh` is bound, so the `finally` is always safe; it also still avoids finalizing a session the caller owns on non-gmsh backends.

## 2. Same `try/finally` treatment for the other two export methods

`export_gmsh_mesh_file()` and `export_unstructured_mesh_file()` called `init_gmsh()` then `gmsh.finalize()` only at the very end, so a mid-mesh exception left the session open until the next `init_gmsh()` self-heal. Both now use the same `try/finally` + `gmsh_session_started` pattern, so the session is finalized on every exit path.

## Tests

`tests/test_gmsh_session_cleanup.py` gains three tests, each red-green verified (fails before the corresponding change, passes after):

- `test_gmsh_export_propagates_error_raised_before_session_starts` — the original error propagates (not `UnboundLocalError`) when the gmsh path fails before the session starts.
- `test_export_gmsh_mesh_file_finalizes_on_meshing_error` — session finalized when `export_gmsh_mesh_file` meshing raises.
- `test_export_unstructured_mesh_file_finalizes_on_meshing_error` — session finalized when `export_unstructured_mesh_file` meshing raises.

All existing gmsh/cadquery tests continue to pass.
