### PR TITLE
Use the BOPAlgo_Builder imprint with glue partial when available

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -29,6 +29,38 @@ class PyMoabNotFoundError(ImportError):
         super().__init__(message)
 
 
+def imprint_assembly(assembly):
+    """Imprint a CadQuery assembly into a connected compound.
+
+    Uses the BOPAlgo_Builder based imprint with glue="partial" when the
+    installed cadquery supports it (CadQuery/cadquery#2069, faster and
+    lower RAM than the older BOPAlgo_MakeConnected based imprint, with the
+    same result for touching, non-overlapping solids). Older cadquery
+    versions fall back to the original single-argument imprint.
+
+    Returns:
+        (imprinted_shape, imprinted_solids_with_original_ids)
+    """
+    import inspect
+
+    # Imprinting needs at least two solids to do anything. Skipping it for a
+    # single solid is not just an optimization: the BOPAlgo_Builder based
+    # imprint returns a Null shape when given fewer than two arguments.
+    id_map = {}
+    for obj, name, loc, _ in assembly:
+        for solid in obj.moved(loc).Solids():
+            id_map[solid] = name
+    if len(id_map) < 2:
+        solids = list(id_map)
+        compound = cq.occ_impl.shapes.Compound.makeCompound(solids)
+        return compound, {s: (id_map[s],) for s in solids}
+
+    imprint = cq.occ_impl.assembly.imprint
+    if "glue" in inspect.signature(imprint).parameters:
+        return imprint(assembly, glue="partial")
+    return imprint(assembly)
+
+
 def define_moab_core_and_tags():
     """Creates a MOAB Core instance which can be built up by adding sets of
     triangles to the instance
@@ -1454,7 +1486,7 @@ class CadToDagmc:
 
         if imprint:
             print("Imprinting assembly for unstructured mesh generation")
-            imprinted_assembly, _ = cq.occ_impl.assembly.imprint(assembly)
+            imprinted_assembly, _ = imprint_assembly(assembly)
         else:
             imprinted_assembly = assembly
 
@@ -1569,7 +1601,7 @@ class CadToDagmc:
 
         if imprint:
             print("Imprinting assembly for mesh generation")
-            imprinted_assembly, _ = cq.occ_impl.assembly.imprint(assembly)
+            imprinted_assembly, _ = imprint_assembly(assembly)
         else:
             imprinted_assembly = assembly
 
@@ -1860,7 +1892,7 @@ class CadToDagmc:
                 if imprint:
                     print("Imprinting assembly for mesh generation")
                     imprinted_assembly, imprinted_solids_with_org_id = (
-                        cq.occ_impl.assembly.imprint(assembly)
+                        imprint_assembly(assembly)
                     )
 
                     scrambled_ids = get_ids_from_imprinted_assembly(


### PR DESCRIPTION
cadquery's upcoming imprint rework (CadQuery/cadquery#2069) replaces BOPAlgo_MakeConnected with a BOPAlgo_Builder based implementation that is faster and uses less RAM on large models. Called with glue="partial" it produces the same imprinted topology as the current imprint for touching, non-overlapping solids.

This PR routes the three imprint call sites through a new module-level imprint_assembly() helper:

- When the installed cadquery's imprint has a glue parameter (the PR branch / future releases), it calls imprint(assembly, glue="partial").
- Otherwise it falls back to the single-argument imprint, so release cadquery keeps working unchanged (no version pin, no behavior change today).
- Single-solid assemblies skip imprinting entirely. It is a no-op for one solid, and the BOPAlgo_Builder imprint returns a Null shape when given fewer than two arguments, which otherwise crashes downstream shape handling. The skip path returns the same (compound, {solid: (name,)}) structure the real imprint produces.

Verified on a 4-shell reactor radial build (nested touching torus shells, cadquery installed from the PR branch): identical surface count and shared-interface topology to the old imprint, watertight DAGMC output, zero lost particles in an OpenMC fixed-source run. Also verified the fallback path against release-style cadquery behavior via the signature check.