### PR TITLE
Offer the cad-to-dagmc-mesher backend for tet meshes

### DIFF
--- a/.github/workflows/ci_with_conda_install.yml
+++ b/.github/workflows/ci_with_conda_install.yml
@@ -89,4 +89,5 @@ jobs:
           python examples/unstrucutred_volume_mesh/curved_cadquery_object_to_dagmc_volume_mesh.py
           python examples/unstrucutred_volume_mesh/simulate_unstrucutred_volume_mesh_with_openmc.py
           python examples/unstrucutred_volume_mesh/different_resolution_meshes.py
+          python examples/unstrucutred_volume_mesh/cadquery_object_to_volume_mesh_with_mesher_backend.py
           python examples/surface_and_unstructured_mesh/unstructured_mesh_with_conformal_surface_mesh.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ flowchart LR
         direction TB
         GMSH_E["  GMSH  "]
         CQ_E["  CadQuery  "]
+        MESHER_E["  cad-to-dagmc-mesher  "]
     end
 
     subgraph h5m_backend [" "]
@@ -42,12 +43,13 @@ flowchart LR
 
     CQ & STEP & GMSH_IN --> TAG
 
-    TAG --> GMSH_E & CQ_E
+    TAG --> GMSH_E & CQ_E & MESHER_E
 
-    GMSH_E & CQ_E --> H5PY & MOAB
+    GMSH_E & CQ_E & MESHER_E --> H5PY & MOAB
     H5PY & MOAB --> H5M
 
     GMSH_E --> VTK & MSH
+    MESHER_E --> VTK
 
     style inputs fill:none,stroke:none
     style tagging fill:none,stroke:none
@@ -63,6 +65,7 @@ flowchart LR
 
     style GMSH_E fill:#f3e8ff,stroke:#9333ea,stroke-width:1.5px,color:#581c87
     style CQ_E fill:#f3e8ff,stroke:#9333ea,stroke-width:1.5px,color:#581c87
+    style MESHER_E fill:#f3e8ff,stroke:#9333ea,stroke-width:1.5px,color:#581c87
 
     style H5PY fill:#fce7f3,stroke:#db2777,stroke-width:1.5px,color:#831843
     style MOAB fill:#fce7f3,stroke:#db2777,stroke-width:1.5px,color:#831843
@@ -86,8 +89,8 @@ flowchart LR
 |---|---|
 | **Multiple Input Formats** | **Flexible Material Tagging** |
 | - CadQuery objects<br>- STEP files<br>- GMSH mesh files | - Manual tags<br>- Assembly names<br>- CadQuery Materials<br>- GMSH physical groups |
-| **Two Meshing Backends** | **Multiple Output Formats** |
-| - GMSH (full control, volume meshing)<br>- CadQuery (simpler, direct) | - DAGMC h5m (surface mesh)<br>- Unstructured VTK (volume mesh)<br>- GMSH files |
+| **Three Meshing Backends** | **Multiple Output Formats** |
+| - GMSH (full control, volume meshing)<br>- CadQuery (simpler, direct)<br>- cad-to-dagmc-mesher (surface and volume meshing) | - DAGMC h5m (surface mesh)<br>- Unstructured VTK (volume mesh)<br>- GMSH files |
 | **Two H5M Backends** | **Advanced Options** |
 | - h5py (default, no MOAB needed)<br>- pymoab (official MOAB) | - Per-volume mesh sizing<br>- Geometry scaling<br>- Parallel meshing |
 
@@ -140,6 +143,7 @@ outputs/conformal_meshes
 meshing/index
 meshing/gmsh_backend
 meshing/cadquery_backend
+meshing/cad_to_dagmc_mesher_backend
 meshing/mesh_sizing
 ```
 

--- a/docs/meshing/cad_to_dagmc_mesher_backend.md
+++ b/docs/meshing/cad_to_dagmc_mesher_backend.md
@@ -49,7 +49,7 @@ model.export_unstructured_mesh_file(
 
 ## Surface and Volume Mesh in One Call
 
-`export_dagmc_h5m_file` can write the DAGMC h5m file and the unstructured volume mesh vtk file from a single meshing call. Provide both `tet_volumes` and `target_edge_length` and the export returns a `(dagmc_filename, umesh_filename)` tuple:
+`export_dagmc_h5m_file` can write the DAGMC h5m file and the unstructured volume mesh vtk file from a single meshing call. The two meshes are conformal: for tet-meshed volumes the surface is remeshed to near-equilateral triangles at `target_edge_length`, that surface is used as the DAGMC tracking surface, and the volume mesher fills it with tetrahedra while preserving the boundary vertices and triangles exactly. Provide both `tet_volumes` and `target_edge_length` and the export returns a `(dagmc_filename, umesh_filename)` tuple:
 
 <!--pytest-codeblocks:skip-->
 ```python

--- a/docs/meshing/cad_to_dagmc_mesher_backend.md
+++ b/docs/meshing/cad_to_dagmc_mesher_backend.md
@@ -1,0 +1,107 @@
+# cad-to-dagmc-mesher Backend
+
+The [cad-to-dagmc-mesher](https://github.com/fusion-energy/cad-to-dagmc-mesher) backend is a purpose-built mesher for DAGMC geometry. It creates triangle surface meshes using constrained Delaunay triangulation and can also fill volumes with tetrahedra, so it can produce both DAGMC h5m files and unstructured volume mesh vtk files without GMSH. It is installed automatically as a dependency of cad_to_dagmc.
+
+## Surface Mesh (h5m)
+
+<!--pytest-codeblocks:skip-->
+```python
+import cadquery as cq
+from cad_to_dagmc import CadToDagmc
+
+assembly = cq.Assembly()
+assembly.add(cq.Workplane("XY").sphere(10))
+
+model = CadToDagmc()
+model.add_cadquery_object(assembly, material_tags=["mat1"])
+
+model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    meshing_backend="cad-to-dagmc-mesher",
+    tolerance=0.01,
+    angular_tolerance=0.2,
+)
+```
+
+## Volume Mesh (vtk)
+
+The backend can write a tetrahedral unstructured volume mesh for use with
+`openmc.UnstructuredMesh(filename, library="moab")`:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_unstructured_mesh_file(
+    filename="umesh.vtk",
+    meshing_backend="cad-to-dagmc-mesher",
+    target_edge_length=2.0,
+)
+```
+
+Passing `target_edge_length` (or `tet_volumes`) selects this backend automatically, so `meshing_backend` can be omitted:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_unstructured_mesh_file(
+    filename="umesh.vtk",
+    target_edge_length=2.0,
+)
+```
+
+## Surface and Volume Mesh in One Call
+
+`export_dagmc_h5m_file` can write the DAGMC h5m file and the unstructured volume mesh vtk file from a single meshing call. Provide both `tet_volumes` and `target_edge_length` and the export returns a `(dagmc_filename, umesh_filename)` tuple:
+
+<!--pytest-codeblocks:skip-->
+```python
+dagmc_filename, umesh_filename = model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    tet_volumes=["mat1"],       # material tag names of volumes to fill with tets
+    target_edge_length=2.0,
+    umesh_filename="umesh.vtk",
+)
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `tolerance` | float | 0.01 | Linear deflection tolerance for the surface mesh |
+| `angular_tolerance` | float | 0.2 | Angular deflection tolerance for the surface mesh |
+| `target_edge_length` | float | None | Target tetrahedron edge length for the volume mesh |
+| `tet_volumes` | Iterable[str] | None | Material tag names of the volumes to fill with tetrahedra |
+
+**Tolerance explanation:**
+- `tolerance` controls how far the surface mesh can deviate from the true surface (linear distance)
+- `angular_tolerance` controls the maximum angle between adjacent facet normals
+- `target_edge_length` controls the size of the tetrahedra in the volume mesh
+
+## Backend Auto-Selection
+
+When `meshing_backend` is not given, the tet arguments select this backend automatically:
+
+- `export_unstructured_mesh_file(..., target_edge_length=...)` uses cad-to-dagmc-mesher; without tet arguments it uses gmsh.
+- `export_dagmc_h5m_file(..., tet_volumes=..., target_edge_length=...)` uses cad-to-dagmc-mesher; mixing these with gmsh-specific arguments (for example `min_mesh_size`) raises an error asking for an explicit `meshing_backend`.
+
+## Advantages
+
+| Advantage | Explanation |
+|-----------|-------------|
+| Volume meshes without GMSH | Writes the vtk file directly |
+| One meshing call for both outputs | h5m and vtk come from the same mesh |
+| Simple configuration | Two surface tolerances plus one tet edge length |
+| Installed with cad_to_dagmc | No extra dependency to install |
+
+## Limitations
+
+| Limitation | Impact |
+|------------|--------|
+| No per-volume sizing | `set_size` parameter is not supported |
+| Single tet size | One `target_edge_length` for all volumes |
+| No mesh algorithm choice | One built-in method |
+
+## See Also
+
+- [GMSH Backend](gmsh_backend.md) - Full-featured meshing backend
+- [CadQuery Backend](cadquery_backend.md) - Surface-only tessellation backend
+- [Unstructured VTK](../outputs/unstructured_vtk.md) - Volume mesh output details
+- [Conformal Meshes](../outputs/conformal_meshes.md) - Matching surface and volume meshes

--- a/docs/meshing/cad_to_dagmc_mesher_backend.md
+++ b/docs/meshing/cad_to_dagmc_mesher_backend.md
@@ -49,7 +49,7 @@ model.export_unstructured_mesh_file(
 
 ## Surface and Volume Mesh in One Call
 
-`export_dagmc_h5m_file` can write the DAGMC h5m file and the unstructured volume mesh vtk file from a single meshing call. The two meshes are conformal: for tet-meshed volumes the surface is remeshed to near-equilateral triangles at `target_edge_length`, that surface is used as the DAGMC tracking surface, and the volume mesher fills it with tetrahedra while preserving the boundary vertices and triangles exactly. Provide both `tet_volumes` and `target_edge_length` and the export returns a `(dagmc_filename, umesh_filename)` tuple:
+`export_dagmc_h5m_file` can write the DAGMC h5m file and the unstructured volume mesh vtk file from a single meshing call. The two meshes are conformal: for tet-meshed volumes the surface is remeshed to near-equilateral triangles at `target_edge_length`, that surface is used as the DAGMC tracking surface, and the volume mesher fills it with tetrahedra whose boundary follows that surface (individual surface triangles may be subdivided in the volume mesh, and on high curvature faces small local deviations up to the chordal error of the tetrahedron edge length can occur). Provide both `tet_volumes` and `target_edge_length` and the export returns a `(dagmc_filename, umesh_filename)` tuple:
 
 <!--pytest-codeblocks:skip-->
 ```python

--- a/docs/meshing/cadquery_backend.md
+++ b/docs/meshing/cadquery_backend.md
@@ -113,4 +113,5 @@ For a simple box, CadQuery will use just 12 triangles (2 per face), while GMSH m
 ## See Also
 
 - [GMSH Backend](gmsh_backend.md) - Full-featured meshing backend
+- [cad-to-dagmc-mesher Backend](cad_to_dagmc_mesher_backend.md) - Surface and volume meshing without GMSH
 - [Mesh Sizing](mesh_sizing.md) - Per-volume mesh control (GMSH only)

--- a/docs/meshing/gmsh_backend.md
+++ b/docs/meshing/gmsh_backend.md
@@ -189,4 +189,5 @@ model.export_unstructured_mesh_file(
 
 - [Mesh Sizing](mesh_sizing.md) - Per-volume mesh control
 - [CadQuery Backend](cadquery_backend.md) - Alternative meshing backend
+- [cad-to-dagmc-mesher Backend](cad_to_dagmc_mesher_backend.md) - Surface and volume meshing without GMSH
 - [Parallel Processing](../advanced/parallel_processing.md) - Thread control

--- a/docs/meshing/index.md
+++ b/docs/meshing/index.md
@@ -1,41 +1,45 @@
 # Meshing Backends
 
-cad_to_dagmc supports two meshing backends for creating surface meshes.
+cad_to_dagmc supports three meshing backends for creating surface and volume meshes.
 
 ## Available Backends
 
 | Backend | Description | Best For |
 |---------|-------------|----------|
-| [GMSH](gmsh_backend.md) | Full-featured meshing library | Complex models, volume meshes |
+| [GMSH](gmsh_backend.md) | Full-featured meshing library | Complex models, fine mesh control |
 | [CadQuery](cadquery_backend.md) | Built-in CadQuery tessellation | Simple models, flat surfaces |
+| [cad-to-dagmc-mesher](cad_to_dagmc_mesher_backend.md) | Purpose-built surface and tetrahedral mesher | Surface and volume meshes without GMSH |
 
 ## Quick Comparison
 
-| Feature | GMSH Backend | CadQuery Backend |
-|---------|--------------|------------------|
-| Surface mesh (h5m) | Yes | Yes |
-| Volume mesh (vtk) | Yes | **No** |
-| Mesh size control | Full (min/max/per-volume) | Limited (tolerance only) |
-| Mesh algorithms | 10 algorithms | 1 (built-in) |
-| Parallel meshing | Yes | Partial |
-| Dependencies | Requires GMSH | Built into CadQuery |
-| Flat surface efficiency | Standard | Better (fewer triangles) |
+| Feature | GMSH | CadQuery | cad-to-dagmc-mesher |
+|---------|------|----------|---------------------|
+| Surface mesh (h5m) | Yes | Yes | Yes |
+| Volume mesh (vtk) | Yes | **No** | Yes |
+| Mesh size control | Full (min/max/per-volume) | Limited (tolerance only) | Tolerances + `target_edge_length` |
+| Mesh algorithms | 10 algorithms | 1 (built-in) | 1 (built-in) |
+| Parallel meshing | Yes | Partial | Yes (DAG scheduler) |
+| Dependencies | Requires GMSH | Built into CadQuery | Installed with cad_to_dagmc |
+| Flat surface efficiency | Standard | Better (fewer triangles) | Better (fewer triangles) |
 
 ## Choosing a Backend
 
-**Use GMSH backend (default) when:**
-- You need volume meshes for unstructured mesh tallies
+**Use GMSH backend when:**
 - You need precise control over mesh density
 - You want per-volume mesh sizing with `set_size`
 - You need parallel meshing for large models
 - You need specific mesh algorithms
 
-**Use CadQuery backend when:**
+**Use CadQuery backend (default for h5m export) when:**
 - You only need surface meshes
 - You want simpler configuration
 - Your geometry has many flat surfaces (fewer triangles)
-- You want to minimize dependencies
 - Your geometry is straightforward
+
+**Use cad-to-dagmc-mesher backend when:**
+- You need volume meshes for unstructured mesh tallies without GMSH
+- You want the surface (h5m) and volume (vtk) meshes from a single meshing call
+- You want simple configuration (tolerances plus one tetrahedron edge length)
 
 ## Basic Usage
 
@@ -49,7 +53,7 @@ assembly.add(cq.Workplane("XY").sphere(10))
 model = CadToDagmc()
 model.add_cadquery_object(assembly, material_tags=["mat1"])
 
-# GMSH backend (default)
+# GMSH backend
 model.export_dagmc_h5m_file(
     filename="dagmc_gmsh.h5m",
     meshing_backend="gmsh",
@@ -63,6 +67,14 @@ model.export_dagmc_h5m_file(
     meshing_backend="cadquery",
     tolerance=0.1,
     angular_tolerance=0.1,
+)
+
+# cad-to-dagmc-mesher backend
+model.export_dagmc_h5m_file(
+    filename="dagmc_mesher.h5m",
+    meshing_backend="cad-to-dagmc-mesher",
+    tolerance=0.01,
+    angular_tolerance=0.2,
 )
 ```
 

--- a/docs/outputs/conformal_meshes.md
+++ b/docs/outputs/conformal_meshes.md
@@ -198,7 +198,7 @@ dagmc_filename = model.export_dagmc_h5m_file(filename="dagmc.h5m")
 
 ## cad-to-dagmc-mesher Alternative
 
-The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) can also produce conformal meshes, without GMSH. It writes the h5m surface mesh and the vtk volume mesh from a single meshing call: for each volume listed in `tet_volumes` the surface is remeshed to near-equilateral triangles at `target_edge_length`, that surface becomes both the DAGMC tracking surface and the tetrahedra boundary, and the volume mesher preserves the boundary vertices and triangles exactly. Provide `tet_volumes` (material tag names) and `target_edge_length`:
+The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) can also produce conformal meshes, without GMSH. It writes the h5m surface mesh and the vtk volume mesh from a single meshing call: for each volume listed in `tet_volumes` the surface is remeshed to near-equilateral triangles at `target_edge_length` and that surface becomes both the DAGMC tracking surface and the tetrahedra boundary, so the two meshes share the same surface (individual surface triangles may be subdivided in the volume mesh, and on high curvature faces small local deviations up to the chordal error of the tetrahedron edge length can occur). Provide `tet_volumes` (material tag names) and `target_edge_length`:
 
 <!--pytest-codeblocks:skip-->
 ```python

--- a/docs/outputs/conformal_meshes.md
+++ b/docs/outputs/conformal_meshes.md
@@ -196,6 +196,20 @@ Without `unstructured_volumes`, it returns just the filename:
 dagmc_filename = model.export_dagmc_h5m_file(filename="dagmc.h5m")
 ```
 
+## cad-to-dagmc-mesher Alternative
+
+The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) can also produce the h5m surface mesh and the vtk volume mesh from a single meshing call, without GMSH. Provide `tet_volumes` (material tag names) and `target_edge_length`:
+
+<!--pytest-codeblocks:skip-->
+```python
+dagmc_filename, umesh_filename = model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    tet_volumes=["steel"],
+    target_edge_length=2.0,
+    umesh_filename="umesh.vtk",
+)
+```
+
 ## See Also
 
 - [DAGMC H5M](dagmc_h5m.md) - Surface mesh output details

--- a/docs/outputs/conformal_meshes.md
+++ b/docs/outputs/conformal_meshes.md
@@ -198,7 +198,7 @@ dagmc_filename = model.export_dagmc_h5m_file(filename="dagmc.h5m")
 
 ## cad-to-dagmc-mesher Alternative
 
-The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) can also produce the h5m surface mesh and the vtk volume mesh from a single meshing call, without GMSH. Provide `tet_volumes` (material tag names) and `target_edge_length`:
+The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) can also produce conformal meshes, without GMSH. It writes the h5m surface mesh and the vtk volume mesh from a single meshing call: for each volume listed in `tet_volumes` the surface is remeshed to near-equilateral triangles at `target_edge_length`, that surface becomes both the DAGMC tracking surface and the tetrahedra boundary, and the volume mesher preserves the boundary vertices and triangles exactly. Provide `tet_volumes` (material tag names) and `target_edge_length`:
 
 <!--pytest-codeblocks:skip-->
 ```python

--- a/docs/outputs/unstructured_vtk.md
+++ b/docs/outputs/unstructured_vtk.md
@@ -3,7 +3,7 @@
 Creates tetrahedral volume meshes for use with OpenMC's `UnstructuredMesh` tally.
 
 :::{note}
-Volume mesh output **requires the GMSH backend**. The CadQuery meshing backend cannot create volume meshes.
+Volume mesh output requires the **GMSH** or **cad-to-dagmc-mesher** backend. The CadQuery meshing backend cannot create volume meshes.
 :::
 
 ## Basic Export
@@ -22,6 +22,29 @@ model.export_unstructured_mesh_file(
     filename="umesh.vtk",
     min_mesh_size=1.0,
     max_mesh_size=5.0,
+)
+```
+
+## Using the cad-to-dagmc-mesher Backend
+
+The [cad-to-dagmc-mesher backend](../meshing/cad_to_dagmc_mesher_backend.md) writes the vtk file without GMSH. The tetrahedra size is controlled with a single `target_edge_length` argument, which also selects the backend automatically:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_unstructured_mesh_file(
+    filename="umesh.vtk",
+    target_edge_length=2.0,
+)
+```
+
+Optionally restrict which volumes are filled with tetrahedra using their material tag names:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_unstructured_mesh_file(
+    filename="umesh.vtk",
+    target_edge_length=2.0,
+    tet_volumes=["tungsten"],
 )
 ```
 
@@ -117,14 +140,17 @@ model.export_unstructured_mesh_file(
 ```python
 model.export_unstructured_mesh_file(
     filename="umesh.vtk",     # Output file path
-    min_mesh_size=1.0,        # Minimum element size
-    max_mesh_size=10.0,       # Maximum element size
+    min_mesh_size=1.0,        # Minimum element size (gmsh backend)
+    max_mesh_size=10.0,       # Maximum element size (gmsh backend)
     mesh_algorithm=1,         # GMSH algorithm (1-10)
-    set_size=None,            # Per-volume sizes
-    volumes=None,             # Specific volumes to include
+    set_size=None,            # Per-volume sizes (gmsh backend)
+    volumes=None,             # Specific volumes to include (gmsh backend)
     scale_factor=1.0,         # Geometry scaling
     imprint=True,             # Imprint shared surfaces
-    method="file",            # CAD transfer method
+    method="file",            # CAD transfer method (gmsh backend)
+    meshing_backend=None,     # "gmsh", "cad-to-dagmc-mesher" or auto-select
+    target_edge_length=None,  # Tet edge length (cad-to-dagmc-mesher backend)
+    tet_volumes=None,         # Volumes to fill with tets (cad-to-dagmc-mesher backend)
 )
 ```
 
@@ -133,14 +159,19 @@ model.export_unstructured_mesh_file(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `filename` | str | "umesh.vtk" | Output VTK file path |
-| `min_mesh_size` | float | None | Minimum mesh element size |
-| `max_mesh_size` | float | None | Maximum mesh element size |
+| `min_mesh_size` | float | None | Minimum mesh element size (gmsh) |
+| `max_mesh_size` | float | None | Maximum mesh element size (gmsh) |
 | `mesh_algorithm` | int | 1 | GMSH meshing algorithm |
-| `set_size` | dict | None | Per-volume mesh sizes |
-| `volumes` | list | None | Specific volumes to mesh |
+| `set_size` | dict | None | Per-volume mesh sizes (gmsh) |
+| `volumes` | list | None | Specific volumes to mesh (gmsh) |
 | `scale_factor` | float | 1.0 | Geometry scale factor |
 | `imprint` | bool | True | Imprint shared surfaces |
-| `method` | str | "file" | CAD transfer method |
+| `method` | str | "file" | CAD transfer method (gmsh) |
+| `meshing_backend` | str | None | "gmsh" or "cad-to-dagmc-mesher"; auto-selected when not set |
+| `target_edge_length` | float | None | Tetrahedron edge length (cad-to-dagmc-mesher) |
+| `tet_volumes` | list[str] | None | Material tags of volumes to fill with tets (cad-to-dagmc-mesher) |
+| `tolerance` | float | 0.01 | Surface mesh linear tolerance (cad-to-dagmc-mesher) |
+| `angular_tolerance` | float | 0.2 | Surface mesh angular tolerance (cad-to-dagmc-mesher) |
 
 ## Using in OpenMC
 
@@ -216,3 +247,4 @@ model.run()
 - [Conformal Meshes](conformal_meshes.md) - When you need matching surface and volume meshes
 - [Per-Volume Mesh Sizing](../meshing/mesh_sizing.md) - Control mesh density
 - [GMSH Backend](../meshing/gmsh_backend.md) - Meshing options
+- [cad-to-dagmc-mesher Backend](../meshing/cad_to_dagmc_mesher_backend.md) - Volume meshes without GMSH

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,9 +70,21 @@ model.export_unstructured_mesh_file(
 )
 ```
 
+The volume mesh can also be produced with the
+[cad-to-dagmc-mesher backend](meshing/cad_to_dagmc_mesher_backend.md) instead of GMSH.
+Passing `target_edge_length` selects it automatically:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_unstructured_mesh_file(
+    filename="umesh.vtk",
+    target_edge_length=2.0,
+)
+```
+
 :::{note}
-Volume mesh export requires the GMSH meshing backend, which is used by default.
-The CadQuery backend only supports surface meshes.
+Volume mesh export requires the GMSH meshing backend (used by default) or the
+cad-to-dagmc-mesher backend. The CadQuery backend only supports surface meshes.
 :::
 
 ## Creating Conformal Surface and Volume Meshes

--- a/examples/unstrucutred_volume_mesh/cadquery_object_to_volume_mesh_with_mesher_backend.py
+++ b/examples/unstrucutred_volume_mesh/cadquery_object_to_volume_mesh_with_mesher_backend.py
@@ -1,0 +1,30 @@
+from cad_to_dagmc import CadToDagmc
+import cadquery as cq
+
+# This example writes a tetrahedral unstructured volume mesh using the
+# cad-to-dagmc-mesher backend instead of gmsh. The resulting vtk file can be
+# used with openmc.UnstructuredMesh(filename="umesh.vtk", library="moab").
+
+result = cq.Workplane("XY").cylinder(height=10, radius=4)
+result2 = cq.Workplane("XY").moveTo(0, 10).box(10, 10, 10)
+
+my_model = CadToDagmc()
+
+my_model.add_cadquery_object(result, material_tags=["mat1"])
+my_model.add_cadquery_object(result2, material_tags=["mat2"])
+
+# target_edge_length sets the tetrahedron size and also selects the
+# cad-to-dagmc-mesher backend automatically
+my_model.export_unstructured_mesh_file(
+    filename="umesh_mesher.vtk",
+    target_edge_length=2.0,
+)
+
+# the same backend can write the DAGMC h5m file and the volume mesh vtk file
+# from a single meshing call, tet_volumes selects the volumes by material tag
+my_model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    tet_volumes=["mat1"],
+    target_edge_length=2.0,
+    umesh_filename="umesh_mat1.vtk",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gmsh",
     "h5py",
     "cadquery_direct_mesh_plugin>=0.1.0",
-    "cad-to-dagmc-mesher>=0.1.4"
+    "cad-to-dagmc-mesher>=0.1.7"
 # TODO once on pypi include moab here and remove from CI
 # python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
 ]

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1501,7 +1501,7 @@ class CadToDagmc:
         set_size: dict[int | str, float] | None = None,
         volumes: Iterable[int] | None = None,
         threads: int = 0,
-        meshing_backend: str = "gmsh",
+        meshing_backend: str | None = None,
         target_edge_length: float | None = None,
         tet_volumes: Iterable[str] | None = None,
         tolerance: float = 0.01,
@@ -1513,11 +1513,12 @@ class CadToDagmc:
         library. Example useage openmc.UnstructuredMesh(filename="umesh.vtk",
         library="moab").
 
-        The mesh can be produced either with gmsh (the default) or with the
+        The mesh can be produced either with gmsh or with the
         cad-to-dagmc-mesher backend. The gmsh backend uses the min/max mesh
         size and set_size arguments, while the cad-to-dagmc-mesher backend
         uses target_edge_length (and optionally tet_volumes) to control the
-        tetrahedra.
+        tetrahedra. gmsh is used unless meshing_backend or one of the
+        cad-to-dagmc-mesher specific arguments is provided.
 
         Parameters:
         -----------
@@ -1553,7 +1554,9 @@ class CadToDagmc:
             threads: the number of threads for Gmsh to use. 0 uses all
                 available cores (default), 1 uses a single thread.
             meshing_backend: the backend used to generate the tetrahedra, either
-                "gmsh" (default) or "cad-to-dagmc-mesher".
+                "gmsh" or "cad-to-dagmc-mesher". If not set, the backend is
+                auto-selected: "cad-to-dagmc-mesher" when target_edge_length or
+                tet_volumes is provided, otherwise "gmsh".
             target_edge_length: the target tetrahedron edge length used by the
                 cad-to-dagmc-mesher backend. Required when meshing_backend is
                 "cad-to-dagmc-mesher".
@@ -1576,6 +1579,15 @@ class CadToDagmc:
         # The library argument must be set to "moab"
         if Path(filename).suffix != ".vtk":
             raise ValueError("Unstructured mesh filename must have a .vtk extension")
+
+        if meshing_backend is None:
+            # Auto-select the backend: the tet arguments are specific to
+            # cad-to-dagmc-mesher, everything else defaults to gmsh.
+            if target_edge_length is not None or tet_volumes is not None:
+                meshing_backend = "cad-to-dagmc-mesher"
+            else:
+                meshing_backend = "gmsh"
+        print(f"Using meshing backend: {meshing_backend}")
 
         if meshing_backend not in ("gmsh", "cad-to-dagmc-mesher"):
             raise ValueError(
@@ -1846,8 +1858,10 @@ class CadToDagmc:
                 Backend selection:
                 - meshing_backend (str, optional): explicitly specify 'gmsh',
                   'cadquery' or 'cad-to-dagmc-mesher'. If not provided, backend is
-                  auto-selected based on other arguments. Defaults to 'cadquery' if
-                  no backend-specific arguments are given.
+                  auto-selected based on other arguments: tet_volumes or
+                  target_edge_length select 'cad-to-dagmc-mesher', gmsh-specific
+                  arguments select 'gmsh'. Defaults to 'cadquery' if no
+                  backend-specific arguments are given.
                 - h5m_backend (str, optional): 'pymoab' or 'h5py' for writing h5m files.
                   Defaults to 'h5py'.
 
@@ -1919,10 +1933,32 @@ class CadToDagmc:
         h5m_backend = kwargs.pop("h5m_backend", "h5py")
 
         if meshing_backend is None:
-            # Auto-select meshing_backend based on kwargs
+            # Auto-select meshing_backend based on kwargs. Keys shared between
+            # backends cannot drive the selection on their own: tolerance and
+            # angular_tolerance are used by both the cadquery and the
+            # cad-to-dagmc-mesher backends, umesh_filename is used by both the
+            # gmsh and the cad-to-dagmc-mesher backends.
+            mesher_only_keys = {"tet_volumes", "target_edge_length"}
+            gmsh_only_keys = gmsh_keys - {"umesh_filename"}
             has_cadquery = any(key in kwargs for key in cadquery_keys)
             has_gmsh = any(key in kwargs for key in gmsh_keys)
-            if has_cadquery and not has_gmsh:
+            has_mesher = any(key in kwargs for key in mesher_only_keys)
+            if has_mesher:
+                provided_gmsh = [key for key in sorted(gmsh_only_keys) if key in kwargs]
+                if provided_gmsh:
+                    provided_mesher = [
+                        key for key in sorted(mesher_only_keys) if key in kwargs
+                    ]
+                    raise ValueError(
+                        "Ambiguous backend: both cad-to-dagmc-mesher and GMSH-specific arguments provided.\n"
+                        f"cad-to-dagmc-mesher-specific arguments: {sorted(mesher_only_keys)}\n"
+                        f"GMSH-specific arguments: {sorted(gmsh_only_keys)}\n"
+                        f"Provided cad-to-dagmc-mesher arguments: {provided_mesher}\n"
+                        f"Provided GMSH arguments: {provided_gmsh}\n"
+                        "Please provide only one backend's arguments."
+                    )
+                meshing_backend = "cad-to-dagmc-mesher"
+            elif has_cadquery and not has_gmsh:
                 meshing_backend = "cadquery"
             elif has_gmsh and not has_cadquery:
                 meshing_backend = "gmsh"
@@ -1970,13 +2006,14 @@ class CadToDagmc:
 
             # Check for invalid parameters
             unstructured_volumes = kwargs.get("unstructured_volumes")
-            if unstructured_volumes is not None:
+            if unstructured_volumes is not None or kwargs.get("tet_volumes") is not None:
                 raise ValueError(
                     "CadQuery backend cannot be used for volume meshing. "
-                    "unstructured_volumes must be None when using 'cadquery' backend."
+                    "unstructured_volumes and tet_volumes must be None when "
+                    "using 'cadquery' backend."
                 )
 
-            # Warn about unused GMSH parameters
+            # Warn about unused GMSH and cad-to-dagmc-mesher parameters
             gmsh_params = [
                 "min_mesh_size",
                 "max_mesh_size",
@@ -1985,6 +2022,7 @@ class CadToDagmc:
                 "umesh_filename",
                 "method",
                 "threads",
+                "target_edge_length",
             ]
             unused_params = [param for param in gmsh_params if param in kwargs]
             if unused_params:
@@ -2004,9 +2042,14 @@ class CadToDagmc:
             umesh_filename = kwargs.get("umesh_filename", "umesh.vtk")
             threads = kwargs.get("threads", 0)
 
-            # Warn about unused CadQuery parameters
-            cq_params = ["tolerance", "angular_tolerance"]
-            unused_params = [param for param in cq_params if param in kwargs]
+            # Warn about unused CadQuery and cad-to-dagmc-mesher parameters
+            non_gmsh_params = [
+                "tolerance",
+                "angular_tolerance",
+                "tet_volumes",
+                "target_edge_length",
+            ]
+            unused_params = [param for param in non_gmsh_params if param in kwargs]
             if unused_params:
                 warnings.warn(
                     f"The following parameters are ignored when using GMSH backend: "

--- a/tests/test_kwarg_args.py
+++ b/tests/test_kwarg_args.py
@@ -73,6 +73,49 @@ class TestKwargsExportDagmcH5mFile:
                 unstructured_volumes=[1],
             )
 
+    def test_cadquery_backend_with_tet_volumes_raises_error(self, tmp_path):
+        """The CadQuery backend cannot volume mesh, so an explicit cadquery
+        backend combined with tet_volumes must fail fast."""
+        with pytest.raises(
+            ValueError, match="CadQuery backend cannot be used for volume meshing"
+        ):
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "test_invalid_tet.h5m"),
+                meshing_backend="cadquery",
+                tet_volumes=["steel"],
+            )
+
+    def test_mesher_backend_auto_selected_from_tet_volumes(self, tmp_path):
+        """tet_volumes selects the cad-to-dagmc-mesher backend when no
+        meshing_backend is given. The mesher branch then fails fast because
+        target_edge_length is missing, which proves the backend was selected
+        (the cadquery default would have silently ignored tet_volumes)."""
+        with pytest.raises(ValueError, match="requires BOTH tet_volumes"):
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "auto_mesher.h5m"),
+                tet_volumes=["steel"],
+            )
+
+    def test_mesher_backend_auto_selected_from_target_edge_length(self, tmp_path):
+        """target_edge_length selects the cad-to-dagmc-mesher backend when no
+        meshing_backend is given."""
+        with pytest.raises(ValueError, match="requires BOTH tet_volumes"):
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "auto_mesher.h5m"),
+                target_edge_length=1.0,
+            )
+
+    def test_mesher_and_gmsh_args_are_ambiguous(self, tmp_path):
+        """Mixing mesher-specific and gmsh-specific arguments without an
+        explicit meshing_backend raises rather than guessing."""
+        with pytest.raises(ValueError, match="Ambiguous backend"):
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "ambiguous.h5m"),
+                tet_volumes=["steel"],
+                target_edge_length=1.0,
+                min_mesh_size=0.5,
+            )
+
     def test_invalid_meshing_backend_raises_error(self, tmp_path):
         """Test that invalid meshing backend raises ValueError"""
         output_file = tmp_path / "test_invalid_backend.h5m"

--- a/tests/test_write_vtk.py
+++ b/tests/test_write_vtk.py
@@ -191,6 +191,16 @@ def test_export_unstructured_mesh_file_mesher_requires_target_edge_length():
         )
 
 
+def test_export_unstructured_mesh_file_auto_selects_mesher():
+    """Passing a mesher-specific tet argument without meshing_backend selects
+    the cad-to-dagmc-mesher backend automatically. The mesher branch then
+    fails fast on the missing target_edge_length, which proves the backend
+    was selected (the gmsh backend would not raise this error)."""
+    model = CadToDagmc()
+    with pytest.raises(ValueError, match="target_edge_length"):
+        model.export_unstructured_mesh_file("x.vtk", tet_volumes=["mat1"])
+
+
 def test_export_dagmc_h5m_file_mesher_requires_both_tet_args():
     """tet_volumes without target_edge_length must fail fast, not silently skip
     writing the .vtk and change the return type to a bare string."""


### PR DESCRIPTION
The tet meshing support merged in #181 was only reachable by explicitly passing meshing_backend="cad-to-dagmc-mesher", and the docs still presented gmsh as the only backend able to write unstructured volume meshes. This PR makes the mesher a first class tet meshing option.

## Code

- export_dagmc_h5m_file now auto-selects the cad-to-dagmc-mesher backend when tet_volumes or target_edge_length is given. Previously these arguments fell through to the default cadquery backend and were silently ignored (no vtk written, no error). Mixing them with gmsh-specific arguments raises an ambiguity error, matching the existing cadquery/gmsh behaviour. Shared keys (tolerance/angular_tolerance with cadquery, umesh_filename with gmsh) do not drive the selection on their own so existing auto-selection behaviour is unchanged.
- export_unstructured_mesh_file meshing_backend now defaults to None and auto-selects: cad-to-dagmc-mesher when target_edge_length or tet_volumes is provided, gmsh otherwise. Explicit backends behave as before.
- The cadquery backend rejects tet_volumes (it cannot volume mesh) and the gmsh backend warns when tet arguments are ignored, so tet arguments can no longer be dropped silently on any path.

## Docs and examples

- New docs page for the cad-to-dagmc-mesher backend, and the meshing index now compares three backends.
- Volume mesh, conformal mesh and quickstart pages document the mesher option, and the landing page diagram/feature table include it.
- New example script writing a volume mesh with the mesher backend, run in the conda CI examples step.

## Tests

- Auto-selection tests for tet_volumes and target_edge_length, the mesher/gmsh ambiguity error, and the cadquery tet_volumes rejection. These exercise the fail-fast paths so they run even where cad-to-dagmc-mesher is not installed.