### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci_with_benchmarks.yml
+++ b/.github/workflows/ci_with_benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system packages
         run: |

--- a/.github/workflows/ci_with_conda_install.yml
+++ b/.github/workflows/ci_with_conda_install.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system packages
         run: |

--- a/.github/workflows/ci_with_pip_install.yml
+++ b/.github/workflows/ci_with_pip_install.yml
@@ -27,11 +27,11 @@ jobs:
         python-version: [3.12]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system dependencies
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
           sudo apt-get install -y libgl1 libglx-mesa0 libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev libosmesa6 libosmesa6-dev libgles2-mesa-dev libarchive-dev libpangocairo-1.0-0
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
 


### PR DESCRIPTION
Updates all GitHub Actions to their latest major versions to clear the Node deprecation warnings appearing in CI runs:

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v3 (python-publish), v4 (others) | v7 |
| actions/setup-python | v3 (python-publish), v5 (others) | v7 |
| peaceiris/actions-gh-pages | v4 | v4 (already latest major) |

The v3 actions run on a long-deprecated Node runtime and warn on every run; v4/v5 run on Node 20 which is also now deprecated on GitHub hosted runners. The latest majors run on Node 24.

Compatibility checked before bumping:
- All jobs use GitHub hosted runners (ubuntu-latest), which meet the minimum runner version (2.327.1) required by the Node 24 actions.
- checkout v7 blocks checking out fork PRs in pull_request_target / workflow_run workflows; no workflow here uses those triggers.
- setup-python v7 removed the pip-install input; not used here.