### PR TITLE
Use stable cadquery release in CI instead of master

### DIFF
--- a/.github/workflows/ci_with_pip_install.yml
+++ b/.github/workflows/ci_with_pip_install.yml
@@ -43,8 +43,6 @@ jobs:
       - name: Install package and openmc (without pymoab)
         shell: bash
         run: |
-          # install the latest cadquery master branch as it has PR https://github.com/CadQuery/cadquery/pull/1923 merged in
-          python -m pip install git+https://github.com/CadQuery/cadquery
           # Install openmc without moab - openmc tests will be skipped if DAGMC not available
           python -m pip install --extra-index-url https://shimwell.github.io/wheels openmc
           python -m pip install .[tests]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "trimesh",
     "networkx",
-    "cadquery>=2.6.0",
+    "cadquery>=2.8.0",
     "numpy",
     "gmsh",
     "h5py",


### PR DESCRIPTION
CI installs cadquery from the master branch:

```yaml
# install the latest cadquery master branch as it has PR https://github.com/CadQuery/cadquery/pull/1923 merged in
python -m pip install git+https://github.com/CadQuery/cadquery
```

That is no longer necessary. CadQuery PR 1923 merged on 2025-12-12 and is contained in both the 2.7.0 and 2.8.0 releases (v2.8.0 is 40 commits ahead of the merge commit, 0 behind), so a stable release covers it.

Removing the git install lets pip resolve cadquery from PyPI through the project dependencies, and the lower bound is bumped to `cadquery>=2.8.0` to guarantee the required behaviour.

Verified locally against cadquery 2.8.0 with cadquery-direct-mesh-plugin 0.2.0 and cad-to-dagmc-mesher 0.1.8:

```
182 passed, 2 skipped in 67.26s
```

Stacked on #198, since `core.py` on `main` is currently a placeholder and no CI run can pass until that is restored. This will retarget to `main` once #198 merges.
