### PR TITLE
Prefer cad-to-dagmc-mesher when only shared kwargs are given

### DIFF
--- a/src/cad_to_dagmc/__init__.py
+++ b/src/cad_to_dagmc/__init__.py
@@ -11,7 +11,7 @@ except PackageNotFoundError:
 
     __version__ = get_version(root="..", relative_to=__file__)
 
-__all__ = ["__version__", "PyMoabNotFoundError"]
+__all__ = ["__version__", "PyMoabNotFoundError", "CadToDagmcMesherNotFoundError"]
 
 from .core import *
-from .core import PyMoabNotFoundError
+from .core import PyMoabNotFoundError, CadToDagmcMesherNotFoundError

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Iterable
+import importlib.util
 import cadquery as cq
 import gmsh
 import numpy as np
@@ -27,6 +28,29 @@ class PyMoabNotFoundError(ImportError):
                 "  export_dagmc_h5m_file(..., h5m_backend='h5py')"
             )
         super().__init__(message)
+
+
+class CadToDagmcMesherNotFoundError(ImportError):
+    """Raised when cad-to-dagmc-mesher is not installed but its backend is requested."""
+
+    def __init__(self, message=None):
+        if message is None:
+            message = (
+                "cad-to-dagmc-mesher is not installed. It is not available on "
+                "conda-forge so it cannot be included as a dependency of the "
+                "cad-to-dagmc conda package.\n\n"
+                "Install it with pip, which works alongside a conda installation:\n"
+                "  pip install cad-to-dagmc-mesher\n\n"
+                "Alternatively, use a meshing backend that is always available:\n"
+                "  export_dagmc_h5m_file(..., meshing_backend='cadquery')\n"
+                "  export_dagmc_h5m_file(..., meshing_backend='gmsh')"
+            )
+        super().__init__(message)
+
+
+def _cad_to_dagmc_mesher_is_available() -> bool:
+    """Return True when the cad-to-dagmc-mesher package can be imported."""
+    return importlib.util.find_spec("cad_to_dagmc_mesher") is not None
 
 
 def write_vtk(filename, vertices, tetrahedra):
@@ -1933,11 +1957,12 @@ class CadToDagmc:
         h5m_backend = kwargs.pop("h5m_backend", "h5py")
 
         if meshing_backend is None:
-            # Auto-select meshing_backend based on kwargs. Keys shared between
-            # backends cannot drive the selection on their own: tolerance and
-            # angular_tolerance are used by both the cadquery and the
-            # cad-to-dagmc-mesher backends, umesh_filename is used by both the
-            # gmsh and the cad-to-dagmc-mesher backends.
+            # Auto-select meshing_backend based on kwargs. tolerance and
+            # angular_tolerance are accepted by both the cadquery and the
+            # cad-to-dagmc-mesher backends, and when only those are given the
+            # cad-to-dagmc-mesher backend is preferred. umesh_filename is
+            # shared between the gmsh and cad-to-dagmc-mesher backends and so
+            # never selects a backend on its own.
             mesher_only_keys = {"tet_volumes", "target_edge_length"}
             gmsh_only_keys = gmsh_keys - {"umesh_filename"}
             has_cadquery = any(key in kwargs for key in cadquery_keys)
@@ -1958,10 +1983,6 @@ class CadToDagmc:
                         "Please provide only one backend's arguments."
                     )
                 meshing_backend = "cad-to-dagmc-mesher"
-            elif has_cadquery and not has_gmsh:
-                meshing_backend = "cadquery"
-            elif has_gmsh and not has_cadquery:
-                meshing_backend = "gmsh"
             elif has_cadquery and has_gmsh:
                 provided_cadquery = [key for key in cadquery_keys if key in kwargs]
                 provided_gmsh = [key for key in gmsh_keys if key in kwargs]
@@ -1973,6 +1994,35 @@ class CadToDagmc:
                     f"Provided GMSH arguments: {provided_gmsh}\n"
                     "Please provide only one backend's arguments."
                 )
+            elif has_cadquery:
+                # cadquery_keys is a subset of cad_to_dagmc_mesher_keys, so
+                # reaching here means only keys that both backends accept were
+                # given and the choice is genuinely ambiguous. Prefer the
+                # mesher and make the decision visible.
+                provided_shared = [key for key in sorted(cadquery_keys) if key in kwargs]
+                if not _cad_to_dagmc_mesher_is_available():
+                    raise CadToDagmcMesherNotFoundError(
+                        f"The arguments {provided_shared} are accepted by both the "
+                        "cadquery and the cad-to-dagmc-mesher meshing backends, so "
+                        "the cad-to-dagmc-mesher backend would be selected, but "
+                        "cad-to-dagmc-mesher is not installed. It is not available "
+                        "on conda-forge so it has to be installed separately.\n\n"
+                        "Either install it:\n"
+                        "  pip install cad-to-dagmc-mesher\n\n"
+                        "or ask for the cadquery backend explicitly:\n"
+                        f"  export_dagmc_h5m_file(..., meshing_backend='cadquery', "
+                        f"{provided_shared[0]}=...)"
+                    )
+                warnings.warn(
+                    f"The arguments {provided_shared} are accepted by both the "
+                    "cadquery and the cad-to-dagmc-mesher meshing backends. The "
+                    "cad-to-dagmc-mesher backend has been selected. Pass "
+                    "meshing_backend='cadquery' or "
+                    "meshing_backend='cad-to-dagmc-mesher' to choose explicitly."
+                )
+                meshing_backend = "cad-to-dagmc-mesher"
+            elif has_gmsh:
+                meshing_backend = "gmsh"
             else:
                 meshing_backend = "cadquery"  # default
 
@@ -2303,7 +2353,10 @@ def _mesh_with_cad_to_dagmc_mesher(
     when no solids were volume-meshed. Volume meshing only happens when both
     ``tet_volumes`` and ``target_edge_length`` are supplied.
     """
-    from cad_to_dagmc_mesher.cad import mesh_assembly
+    try:
+        from cad_to_dagmc_mesher.cad import mesh_assembly
+    except ImportError as e:
+        raise CadToDagmcMesherNotFoundError() from e
 
     result = mesh_assembly(
         assembly,

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1960,9 +1960,12 @@ class CadToDagmc:
             # Auto-select meshing_backend based on kwargs. tolerance and
             # angular_tolerance are accepted by both the cadquery and the
             # cad-to-dagmc-mesher backends, and when only those are given the
-            # cad-to-dagmc-mesher backend is preferred. umesh_filename is
-            # shared between the gmsh and cad-to-dagmc-mesher backends and so
-            # never selects a backend on its own.
+            # cad-to-dagmc-mesher backend is preferred.
+            # Note that umesh_filename is also accepted by both the gmsh and
+            # the cad-to-dagmc-mesher backends but is not treated as shared
+            # here: it is part of gmsh_keys, so it selects gmsh on its own and
+            # combining it with tolerance reports an ambiguity. Only
+            # gmsh_only_keys excludes it, and only in the has_mesher branch.
             mesher_only_keys = {"tet_volumes", "target_edge_length"}
             gmsh_only_keys = gmsh_keys - {"umesh_filename"}
             has_cadquery = any(key in kwargs for key in cadquery_keys)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,14 @@ except ImportError:
 
 
 
+def pytest_configure(config):
+    """Register the markers used to declare optional dependencies."""
+    config.addinivalue_line(
+        "markers",
+        "requires_mesher: test needs cad-to-dagmc-mesher to be installed",
+    )
+
+
 def pytest_addoption(parser):
     """Add command-line option for h5m backend."""
     parser.addoption(
@@ -42,6 +50,11 @@ def pytest_collection_modifyitems(config, items):
     skip_pymoab = pytest.mark.skip(reason="pymoab not installed")
     skip_mesher = pytest.mark.skip(reason="cad-to-dagmc-mesher not installed")
     for item in items:
+        # Skip tests that ask for the mesher directly rather than through a
+        # meshing_backend parameter
+        if not MESHER_AVAILABLE and item.get_closest_marker("requires_mesher"):
+            item.add_marker(skip_mesher)
+
         # Check if the test is parametrized
         if hasattr(item, "callspec") and item.callspec.params:
             params = item.callspec.params

--- a/tests/test_kwarg_args.py
+++ b/tests/test_kwarg_args.py
@@ -3,7 +3,7 @@ import warnings
 import cadquery as cq
 import pytest
 
-from cad_to_dagmc import CadToDagmc
+from cad_to_dagmc import CadToDagmc, CadToDagmcMesherNotFoundError
 
 
 class TestKwargsExportDagmcH5mFile:
@@ -46,6 +46,7 @@ class TestKwargsExportDagmcH5mFile:
         assert result == str(output_file)
         assert output_file.exists()
 
+    @pytest.mark.requires_mesher
     def test_cad_to_dagmc_mesher_backend_with_tolerance_params(self, tmp_path):
         """Test cad-to-dagmc-mesher backend with tolerance parameters"""
         output_file = tmp_path / "test_mesher.h5m"
@@ -115,6 +116,150 @@ class TestKwargsExportDagmcH5mFile:
                 target_edge_length=1.0,
                 min_mesh_size=0.5,
             )
+
+    @pytest.mark.requires_mesher
+    @pytest.mark.parametrize(
+        "shared_kwargs",
+        [
+            {"tolerance": 0.05},
+            {"angular_tolerance": 0.2},
+            {"tolerance": 0.05, "angular_tolerance": 0.2},
+        ],
+    )
+    def test_shared_kwargs_select_mesher_and_warn(self, tmp_path, shared_kwargs):
+        """tolerance and angular_tolerance are accepted by both the cadquery
+        and the cad-to-dagmc-mesher backends, so the mesher is preferred and
+        the choice is reported."""
+        output_file = tmp_path / "shared_kwargs.h5m"
+
+        with pytest.warns(UserWarning, match="cad-to-dagmc-mesher backend has been"):
+            result = self.my_model.export_dagmc_h5m_file(
+                filename=str(output_file), **shared_kwargs
+            )
+
+        assert result == str(output_file)
+        assert output_file.exists()
+
+    @pytest.mark.requires_mesher
+    def test_shared_kwargs_warning_names_the_provided_arguments(self, tmp_path):
+        """The warning lists the shared arguments that triggered the choice."""
+        with pytest.warns(UserWarning) as record:
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "named_args.h5m"), tolerance=0.05
+            )
+
+        message = str(record[0].message)
+        assert "tolerance" in message
+        assert "angular_tolerance" not in message
+
+    def test_explicit_backend_overrides_shared_kwarg_preference(self, tmp_path):
+        """An explicit meshing_backend wins over the shared kwarg preference,
+        and no ambiguity warning is emitted."""
+        output_file = tmp_path / "explicit_cadquery.h5m"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            result = self.my_model.export_dagmc_h5m_file(
+                filename=str(output_file),
+                meshing_backend="cadquery",
+                tolerance=0.05,
+            )
+
+        assert result == str(output_file)
+        assert output_file.exists()
+        assert not [
+            warning
+            for warning in w
+            if "cad-to-dagmc-mesher backend has been" in str(warning.message)
+        ]
+
+    def test_shared_kwargs_with_gmsh_args_still_ambiguous(self, tmp_path):
+        """Preferring the mesher for shared kwargs must not swallow the
+        existing CadQuery and GMSH ambiguity error."""
+        with pytest.raises(ValueError, match="Ambiguous backend"):
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "cq_gmsh_ambiguous.h5m"),
+                tolerance=0.05,
+                min_mesh_size=0.5,
+            )
+
+    def test_gmsh_only_args_still_select_gmsh(self, tmp_path):
+        """gmsh-specific arguments alone still select the gmsh backend."""
+        output_file = tmp_path / "auto_gmsh.h5m"
+
+        result = self.my_model.export_dagmc_h5m_file(
+            filename=str(output_file), max_mesh_size=1.0
+        )
+
+        assert result == str(output_file)
+        assert output_file.exists()
+
+    def test_shared_kwargs_without_mesher_installed_raises_helpful_error(
+        self, tmp_path, monkeypatch
+    ):
+        """cad-to-dagmc-mesher is not on conda-forge, so when it would be auto
+        selected but is missing the user is told how to proceed."""
+        monkeypatch.setattr(
+            "cad_to_dagmc.core._cad_to_dagmc_mesher_is_available", lambda: False
+        )
+
+        with pytest.raises(CadToDagmcMesherNotFoundError) as excinfo:
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "no_mesher.h5m"), tolerance=0.05
+            )
+
+        message = str(excinfo.value)
+        assert "pip install cad-to-dagmc-mesher" in message
+        assert "meshing_backend='cadquery'" in message
+        assert "tolerance" in message
+
+    def test_explicit_cadquery_works_without_mesher_installed(
+        self, tmp_path, monkeypatch
+    ):
+        """The remedy the error suggests actually works."""
+        monkeypatch.setattr(
+            "cad_to_dagmc.core._cad_to_dagmc_mesher_is_available", lambda: False
+        )
+        output_file = tmp_path / "explicit_cq_no_mesher.h5m"
+
+        result = self.my_model.export_dagmc_h5m_file(
+            filename=str(output_file), meshing_backend="cadquery", tolerance=0.05
+        )
+
+        assert result == str(output_file)
+        assert output_file.exists()
+
+    def test_no_backend_args_without_mesher_installed_still_works(
+        self, tmp_path, monkeypatch
+    ):
+        """A plain export must not be affected by the mesher being absent."""
+        monkeypatch.setattr(
+            "cad_to_dagmc.core._cad_to_dagmc_mesher_is_available", lambda: False
+        )
+        output_file = tmp_path / "default_no_mesher.h5m"
+
+        result = self.my_model.export_dagmc_h5m_file(filename=str(output_file))
+
+        assert result == str(output_file)
+        assert output_file.exists()
+
+    def test_no_backend_args_still_default_to_cadquery(self, tmp_path):
+        """With no backend selecting arguments the cadquery default stands."""
+        output_file = tmp_path / "auto_default.h5m"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            result = self.my_model.export_dagmc_h5m_file(filename=str(output_file))
+
+        assert result == str(output_file)
+        assert output_file.exists()
+        assert not [
+            warning
+            for warning in w
+            if "cad-to-dagmc-mesher backend has been" in str(warning.message)
+        ]
 
     def test_invalid_meshing_backend_raises_error(self, tmp_path):
         """Test that invalid meshing backend raises ValueError"""


### PR DESCRIPTION
Closes #197.

`tolerance` and `angular_tolerance` are accepted by both the cadquery and the cad-to-dagmc-mesher backends. When only those are provided and no `meshing_backend` is given, the mesher is now selected and a warning reports the decision.

## Deviation from the diff in the issue

The diff proposed in #197 introduces `has_cad_to_dagmc_mesher` and branches on `has_cadquery and has_cad_to_dagmc_mesher`. That guard is always equal to `has_cadquery`, because the key sets overlap by containment:

```python
cadquery_keys            = {"tolerance", "angular_tolerance"}
cad_to_dagmc_mesher_keys = {"tolerance", "angular_tolerance", "tet_volumes", "target_edge_length"}
```

`has_mesher` is handled in an earlier branch, so by the time that guard is reached the only way `has_cad_to_dagmc_mesher` can be true is through the two shared keys, which is exactly `has_cadquery`. Placing it above the existing branches would therefore make two of them unreachable:

- `elif has_cadquery and not has_gmsh: meshing_backend = "cadquery"`
- the `elif has_cadquery and has_gmsh:` block that raises `Ambiguous backend: both CadQuery and GMSH-specific arguments provided`

The second is a behaviour regression that contradicts the issue's own requirement to preserve the existing disambiguation rules. `export_dagmc_h5m_file(tolerance=0.1, min_mesh_size=1)` would stop raising and silently mesh with the mesher.

This PR gets the requested behaviour by moving the CadQuery and GMSH ambiguity check above the new branch instead of adding the redundant variable. Resulting order:

| provided kwargs | selected backend |
|---|---|
| `tet_volumes` or `target_edge_length` | cad-to-dagmc-mesher (unchanged) |
| mesher only keys plus gmsh only keys | `ValueError`, ambiguous (unchanged) |
| shared keys plus gmsh keys | `ValueError`, ambiguous (unchanged) |
| shared keys only | **cad-to-dagmc-mesher, with a warning (new)** |
| gmsh keys only | gmsh (unchanged) |
| none | cadquery (unchanged) |

Explicit `meshing_backend` still overrides everything.

## cad-to-dagmc-mesher is not on conda-forge

Since the mesher cannot be a conda dependency, auto-selecting it would turn a previously working `tolerance=` call into a bare `ModuleNotFoundError` for conda users. When the mesher would be auto selected but is not installed, a `CadToDagmcMesherNotFoundError` now explains both remedies:

```
The arguments ['tolerance'] are accepted by both the cadquery and the
cad-to-dagmc-mesher meshing backends, so the cad-to-dagmc-mesher backend would
be selected, but cad-to-dagmc-mesher is not installed. It is not available on
conda-forge so it has to be installed separately.

Either install it:
  pip install cad-to-dagmc-mesher

or ask for the cadquery backend explicitly:
  export_dagmc_h5m_file(..., meshing_backend='cadquery', tolerance=...)
```

The same error type replaces the bare `ModuleNotFoundError` raised from `_mesh_with_cad_to_dagmc_mesher` when the backend is requested explicitly, mirroring the existing `PyMoabNotFoundError` pattern.

## Testing

11 new tests cover the selection table above, the warning contents, explicit override, and the not installed path.

Tests that need the mesher installed are now marked `requires_mesher` and skipped by `conftest.py` when it is absent. This also fixes a pre-existing gap: `test_cad_to_dagmc_mesher_backend_with_tolerance_params` passes the backend as an argument rather than a parametrization, so the existing conftest skip never caught it and it failed in any environment without the mesher.

Verified both ways locally:

```
with cad-to-dagmc-mesher installed:     193 passed, 2 skipped
without cad-to-dagmc-mesher installed:  167 passed, 24 skipped
```

The second run simulates the conda-forge environment. The five test files the feedstock runs give 54 passed, 16 skipped, 0 failed there.
