### PR TITLE
Smoke test built distributions before publishing to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,11 +30,37 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel build twine
 
-    - name: Build and publish
+    - name: Build
+      run: |
+        python -m build
+        twine check dist/*
+
+    - name: Install system dependencies for the smoke tests
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libgl1 libglx-mesa0 libglu1-mesa-dev libosmesa6 libxcursor-dev libxft2 libxinerama-dev
+
+    # twine check only validates packaging metadata. It happily passes a
+    # distribution whose modules are corrupt, which is how the unimportable
+    # 0.12.1 and 0.12.2 releases reached PyPI. Installing each distribution
+    # into a clean environment and importing it fails the job before upload.
+    - name: Smoke test the wheel
+      run: |
+        python -m venv /tmp/smoke-wheel
+        /tmp/smoke-wheel/bin/python -m pip install --quiet dist/*.whl
+        /tmp/smoke-wheel/bin/python -c "import cad_to_dagmc; print('wheel imports', cad_to_dagmc.__version__)"
+
+    # The sdist is checked separately because conda-forge builds from it
+    # rather than from the wheel.
+    - name: Smoke test the sdist
+      run: |
+        python -m venv /tmp/smoke-sdist
+        /tmp/smoke-sdist/bin/python -m pip install --quiet dist/*.tar.gz
+        /tmp/smoke-sdist/bin/python -c "import cad_to_dagmc; print('sdist imports', cad_to_dagmc.__version__)"
+
+    - name: Publish
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-        python -m build
-        twine check dist/*
         twine upload dist/*


### PR DESCRIPTION
`twine check` only validates packaging metadata. It passes a distribution whose modules are corrupt, which is exactly how the unimportable 0.12.1 and 0.12.2 releases reached PyPI: `src/cad_to_dagmc/core.py` had been reduced to a 17 byte `<REPLACE_CONTENT>` placeholder and the upload still succeeded.

This adds an import gate between building and uploading. The wheel and the sdist are each installed into a clean virtual environment and imported, so a broken build fails the job rather than being published.

The sdist is checked separately from the wheel because conda-forge builds from the sdist, and that is the artifact that broke the feedstock.

## Verification

I rebuilt a wheel from the current tree with `core.py` replaced by the same placeholder, then ran both gates against it.

The gate we have today:

```
$ twine check dist/cad_to_dagmc-...-py3-none-any.whl
Checking dist/cad_to_dagmc-...-py3-none-any.whl: PASSED
```

The gate this PR adds:

```
$ python -c "import cad_to_dagmc"
  File ".../cad_to_dagmc/core.py", line 1
    <REPLACE_CONTENT>
    ^
SyntaxError: invalid syntax

$ echo $?
1
```

A non-zero exit fails the step, so `twine upload` never runs.

## Cost

The publish workflow only runs on a release, so the extra couple of minutes is cheap insurance. A trimmed set of system libraries is installed for the imports, since importing cadquery pulls in OCP which needs libGL.

Note that because 0.12.1 and 0.12.2 were removed from PyPI, those version numbers cannot be reused, so the next release has to be 0.12.3 or higher.
