### PR TITLE
Report backend ambiguity without mislabelling shared arguments

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1961,11 +1961,13 @@ class CadToDagmc:
             # angular_tolerance are accepted by both the cadquery and the
             # cad-to-dagmc-mesher backends, and when only those are given the
             # cad-to-dagmc-mesher backend is preferred.
-            # Note that umesh_filename is also accepted by both the gmsh and
-            # the cad-to-dagmc-mesher backends but is not treated as shared
-            # here: it is part of gmsh_keys, so it selects gmsh on its own and
-            # combining it with tolerance reports an ambiguity. Only
-            # gmsh_only_keys excludes it, and only in the has_mesher branch.
+            # umesh_filename is accepted by both the gmsh and the
+            # cad-to-dagmc-mesher backends, so it is not gmsh specific, but it
+            # is still part of gmsh_keys because it selects gmsh when nothing
+            # else narrows the choice. Combining it with tolerance stays
+            # ambiguous: the mesher only honours umesh_filename when
+            # tet_volumes and target_edge_length are supplied too, so no single
+            # backend accepts that combination as given.
             mesher_only_keys = {"tet_volumes", "target_edge_length"}
             gmsh_only_keys = gmsh_keys - {"umesh_filename"}
             has_cadquery = any(key in kwargs for key in cadquery_keys)
@@ -1987,16 +1989,30 @@ class CadToDagmc:
                     )
                 meshing_backend = "cad-to-dagmc-mesher"
             elif has_cadquery and has_gmsh:
-                provided_cadquery = [key for key in cadquery_keys if key in kwargs]
-                provided_gmsh = [key for key in gmsh_keys if key in kwargs]
-                raise ValueError(
-                    "Ambiguous backend: both CadQuery and GMSH-specific arguments provided.\n"
-                    f"CadQuery-specific arguments: {sorted(cadquery_keys)}\n"
-                    f"GMSH-specific arguments: {sorted(gmsh_keys)}\n"
-                    f"Provided CadQuery arguments: {provided_cadquery}\n"
-                    f"Provided GMSH arguments: {provided_gmsh}\n"
-                    "Please provide only one backend's arguments."
+                provided_cadquery = [key for key in sorted(cadquery_keys) if key in kwargs]
+                provided_gmsh_only = [
+                    key for key in sorted(gmsh_only_keys) if key in kwargs
+                ]
+                provided_gmsh_shared = [
+                    key for key in sorted(gmsh_keys - gmsh_only_keys) if key in kwargs
+                ]
+                message = (
+                    "Ambiguous backend: the arguments provided are not all accepted "
+                    "by any single meshing backend.\n"
+                    f"Accepted by cadquery and cad-to-dagmc-mesher: {provided_cadquery}\n"
                 )
+                if provided_gmsh_only:
+                    message += f"Accepted by gmsh only: {provided_gmsh_only}\n"
+                if provided_gmsh_shared:
+                    message += (
+                        "Accepted by gmsh and cad-to-dagmc-mesher: "
+                        f"{provided_gmsh_shared}\n"
+                        "Note that cad-to-dagmc-mesher only writes an unstructured "
+                        "volume mesh when tet_volumes and target_edge_length are "
+                        "also given.\n"
+                    )
+                message += "Please set meshing_backend explicitly."
+                raise ValueError(message)
             elif has_cadquery:
                 # cadquery_keys is a subset of cad_to_dagmc_mesher_keys, so
                 # reaching here means only keys that both backends accept were

--- a/tests/test_kwarg_args.py
+++ b/tests/test_kwarg_args.py
@@ -184,6 +184,50 @@ class TestKwargsExportDagmcH5mFile:
                 min_mesh_size=0.5,
             )
 
+    def test_ambiguity_message_does_not_call_umesh_filename_gmsh_specific(
+        self, tmp_path
+    ):
+        """umesh_filename is accepted by gmsh and cad-to-dagmc-mesher, so the
+        ambiguity error must not describe it as gmsh specific, and it should
+        say why the mesher cannot simply be used instead."""
+        with pytest.raises(ValueError) as excinfo:
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "umesh_ambiguous.h5m"),
+                tolerance=0.05,
+                umesh_filename=str(tmp_path / "umesh_ambiguous.vtk"),
+            )
+
+        message = str(excinfo.value)
+        assert "Accepted by gmsh and cad-to-dagmc-mesher: ['umesh_filename']" in message
+        assert "Accepted by gmsh only" not in message
+        assert "tet_volumes and target_edge_length" in message
+        assert "meshing_backend" in message
+
+    def test_ambiguity_message_separates_gmsh_only_arguments(self, tmp_path):
+        """Genuinely gmsh specific arguments are reported as such."""
+        with pytest.raises(ValueError) as excinfo:
+            self.my_model.export_dagmc_h5m_file(
+                filename=str(tmp_path / "gmsh_ambiguous.h5m"),
+                tolerance=0.05,
+                min_mesh_size=0.5,
+            )
+
+        message = str(excinfo.value)
+        assert "Accepted by gmsh only: ['min_mesh_size']" in message
+        assert "Accepted by cadquery and cad-to-dagmc-mesher: ['tolerance']" in message
+
+    def test_umesh_filename_alone_still_selects_gmsh(self, tmp_path):
+        """umesh_filename on its own remains a gmsh request."""
+        output_file = tmp_path / "umesh_only.h5m"
+
+        result = self.my_model.export_dagmc_h5m_file(
+            filename=str(output_file),
+            umesh_filename=str(tmp_path / "umesh_only.vtk"),
+        )
+
+        assert result == str(output_file)
+        assert output_file.exists()
+
     def test_gmsh_only_args_still_select_gmsh(self, tmp_path):
         """gmsh-specific arguments alone still select the gmsh backend."""
         output_file = tmp_path / "auto_gmsh.h5m"


### PR DESCRIPTION
The ambiguity error in `export_dagmc_h5m_file` described every entry of `gmsh_keys` as GMSH-specific, including `umesh_filename`, which is also accepted by the cad-to-dagmc-mesher backend.

So passing `tolerance` together with `umesh_filename` produced:

```
Ambiguous backend: both CadQuery and GMSH-specific arguments provided.
CadQuery-specific arguments: ['angular_tolerance', 'tolerance']
GMSH-specific arguments: ['max_mesh_size', 'mesh_algorithm', 'method', 'min_mesh_size',
                          'set_size', 'threads', 'umesh_filename', 'unstructured_volumes']
Provided CadQuery arguments: ['tolerance']
Provided GMSH arguments: ['umesh_filename']
Please provide only one backend's arguments.
```

which sends the reader looking for a CadQuery versus GMSH conflict that is not really there.

## Selection behaviour is unchanged

I first tried routing this combination to cad-to-dagmc-mesher, on the grounds that it is the only backend accepting both keys. That is wrong. The mesher only honours `umesh_filename` when `tet_volumes` and `target_edge_length` are supplied as well, so it fails a step later with:

```
ValueError: Writing an unstructured volume mesh with the cad-to-dagmc-mesher backend
requires BOTH tet_volumes (material tag names) and target_edge_length.
Got tet_volumes=None, target_edge_length=None.
```

That just swaps one confusing error for another. The combination really is under specified, so raising is correct and this PR changes only the message. `umesh_filename` on its own still selects gmsh, and `tolerance` plus a gmsh only key still raises.

## New message

```
Ambiguous backend: the arguments provided are not all accepted by any single meshing backend.
Accepted by cadquery and cad-to-dagmc-mesher: ['tolerance']
Accepted by gmsh and cad-to-dagmc-mesher: ['umesh_filename']
Note that cad-to-dagmc-mesher only writes an unstructured volume mesh when tet_volumes and target_edge_length are also given.
Please set meshing_backend explicitly.
```

Arguments are grouped by which backends accept them, and only genuinely gmsh specific keys are reported under `Accepted by gmsh only`, which is the case for the `tolerance` plus `min_mesh_size` combination.

## Possible follow up

An alternative would be to send `tolerance` plus `umesh_filename` to gmsh, since gmsh can satisfy the `umesh_filename` request and `tolerance` would be reported by the existing ignored parameter warning. I did not do that here because silently ignoring a supplied argument is what the ambiguity check exists to prevent, but it is a reasonable call to make differently.

## Testing

Two new tests cover the message content for the shared key case and the gmsh only case.

```
with cad-to-dagmc-mesher installed:     196 passed, 2 skipped
without cad-to-dagmc-mesher installed:  170 passed, 24 skipped
```
