### PR TITLE
Use the latest openmc and a cadquery floor in the benchmark CI

### DIFF
--- a/.github/workflows/ci_with_benchmarks.yml
+++ b/.github/workflows/ci_with_benchmarks.yml
@@ -44,7 +44,11 @@ jobs:
           source "${HOME}/miniforge/etc/profile.d/conda.sh"
           conda create -n ci-env python=3.11
           conda activate ci-env
-          conda install -c conda-forge "openmc=0.15.0=dagmc*nompi*" trimesh networkx cadquery gmsh python-gmsh
+          # cadquery is pinned to the same floor as pyproject.toml so that conda
+          # satisfies it. Otherwise pip resolves cadquery from PyPI on top of the
+          # conda environment, which drags in cadquery-ocp and a second vtk, and
+          # the install fails because pip cannot uninstall the conda provided vtk.
+          conda install -c conda-forge "openmc=0.15.3=dagmc*nompi*" trimesh networkx "cadquery>=2.8.0" cadquery-direct-mesh-plugin gmsh python-gmsh
           python -m pip install .[tests]
           python -m pip install git+https://github.com/svalinn/pydagmc
 


### PR DESCRIPTION
Fixes the vtk conflict that has been failing `CI with model benchmark zoo`.

## Cause

The workflow pinned openmc 0.15.0, a 2024 build, which held the conda solve back to a cadquery older than the `cadquery>=2.8.0` floor now in `pyproject.toml`. `pip install .[tests]` then resolved cadquery from PyPI on top of the conda environment, which pulled in cadquery-ocp and vtk 9.6.2 and failed:

```
Attempting uninstall: vtk
  Found existing installation: vtk 9.3.1
error: uninstall-distutils-installed-package

x Cannot uninstall vtk 9.3.1
`-> It is a distutils installed project and thus we cannot accurately determine
    which files belong to it which would lead to only a partial uninstall.
```

Worth noting that cad_to_dagmc itself does not need vtk. There is no vtk import anywhere in `src/`, and `write_vtk` writes legacy ASCII VTK by hand. vtk arrives purely through the cadquery stack, where `cadquery-ocp` requires it and `cadquery` requires `trame-vtk`. So it cannot be removed from our side, only kept consistent.

## Fix

Bump openmc to 0.15.3, the current conda-forge release, and pin cadquery to the same floor as `pyproject.toml` so conda satisfies it and pip has nothing left to replace.

openmc 0.15.3 is a good fit for this:

```
dagmc_nompi builds exist for py311, py312 and py313
python  >=3.11,<3.12.0a0     (matches the python=3.11 env)
numpy   >=1.23,<3
no vtk dependency at all
```

so it co-solves with cadquery 2.8.0, which needs python >=3.11 and ocp 7.9.3.1.

`cadquery-direct-mesh-plugin` is added to the conda install because it became a runtime dependency in 0.12.0 and is available on conda-forge.

Both sides of every benchmark run under the same openmc, so moving 0.15.0 to 0.15.3 does not bias the CAD versus CSG comparison.

## Note on what this does not fix

The benchmark comparisons currently fail for the `kwargs1` parametrisation, which is the cadquery backend at `tolerance=0.1, angular_tolerance=0.1`. Those failures are systematic and one directional, with CSG consistently above CAD by between 1.7% and 37%, and they look like chordal faceting bias rather than an environment problem. The gmsh parametrisation and the cad-to-dagmc-mesher parametrisation at `tolerance=0.01` both pass. That is a separate issue from this dependency conflict.
