### PR TITLE
Require cad-to-dagmc-mesher 0.1.9 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gmsh",
     "h5py",
     "cadquery_direct_mesh_plugin>=0.2.0",
-    "cad-to-dagmc-mesher>=0.1.8"
+    "cad-to-dagmc-mesher>=0.1.9"
 # TODO if moab become available on pypi include moab here and remove from CI
 # python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
 ]


### PR DESCRIPTION
> **Draft until cad-to-dagmc-mesher 0.1.9 is on PyPI.** The latest release there is still 0.1.8, so CI on this branch will fail with `No matching distribution found for cad-to-dagmc-mesher>=0.1.9` until the release exists. Mark ready once it is published.

cad-to-dagmc-mesher 0.1.8 fails whenever cadquery and ocp come from conda-forge rather than PyPI:

```
File ".../cad_to_dagmc_mesher/cad/_assembly.py", line 170, in extract_assembly
    solids.append(TopoDS.Solid_s(exp.Current()))
AttributeError: module 'OCP.TopoDS.TopoDS' has no attribute 'Solid_s'
```

The two OCP builds spell the OCCT static methods differently. fusion-energy/cad-to-dagmc-mesher#111 makes the package accept both spellings, and 0.1.9 is the release that carries it.

Raising the floor is required rather than cosmetic. With `>=0.1.8` pip may still resolve 0.1.8, in which case the mesher backend keeps failing in exactly the environments the fix targets.

## Why this matters here

The benchmark CI installs cadquery and ocp from conda-forge and cad-to-dagmc-mesher from PyPI, which is the combination that breaks. In the most recent run on main, 57 of the 59 failures were this single `AttributeError`, all on the `kwargs2` parametrisation that selects the mesher backend.

Expected state once 0.1.9 is released and this merges:

| parametrisation | backend | now | after |
|---|---|---|---|
| kwargs0 | gmsh | pass | pass |
| kwargs1 | cadquery | 2 fail | 2 fail |
| kwargs2 | cad-to-dagmc-mesher | 57 fail | should pass |

The two remaining `kwargs1` assertion failures are unrelated to this and are worth looking at separately. They are down from 23 before the openmc and cadquery bump in #205.

## No conda-forge impact

The conda-forge feedstock does not list cad-to-dagmc-mesher at all, since it is not available there, and `tests/conftest.py` skips the tests that need it. This floor only affects pip installs.
