### PR TITLE
Default to cad-to-dagmc-mesher when no meshing backend is given

### DIFF
--- a/docs/meshing/gmsh_backend.md
+++ b/docs/meshing/gmsh_backend.md
@@ -1,6 +1,6 @@
 # GMSH Backend
 
-The GMSH backend (default) provides full control over mesh parameters and supports both surface and volume meshing.
+The GMSH backend provides full control over mesh parameters and supports both surface and volume meshing.
 
 ## Basic Usage
 

--- a/docs/meshing/index.md
+++ b/docs/meshing/index.md
@@ -30,16 +30,20 @@ cad_to_dagmc supports three meshing backends for creating surface and volume mes
 - You need parallel meshing for large models
 - You need specific mesh algorithms
 
-**Use CadQuery backend (default for h5m export) when:**
+**Use CadQuery backend when:**
 - You only need surface meshes
 - You want simpler configuration
 - Your geometry has many flat surfaces (fewer triangles)
 - Your geometry is straightforward
 
-**Use cad-to-dagmc-mesher backend when:**
+**Use cad-to-dagmc-mesher backend (the default) when:**
 - You need volume meshes for unstructured mesh tallies without GMSH
 - You want the surface (h5m) and volume (vtk) meshes from a single meshing call
 - You want simple configuration (tolerances plus one tetrahedron edge length)
+
+A call that gives no backend and no backend-specific arguments uses
+cad-to-dagmc-mesher. It is installed with the pip package but is not on
+conda-forge, so a conda installation without it falls back to CadQuery.
 
 ## Basic Usage
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -83,8 +83,8 @@ model.export_unstructured_mesh_file(
 ```
 
 :::{note}
-Volume mesh export requires the GMSH meshing backend (used by default) or the
-cad-to-dagmc-mesher backend. The CadQuery backend only supports surface meshes.
+Volume mesh export requires the GMSH meshing backend or the cad-to-dagmc-mesher
+backend. The CadQuery backend only supports surface meshes.
 :::
 
 ## Creating Conformal Surface and Volume Meshes

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1884,8 +1884,9 @@ class CadToDagmc:
                   'cadquery' or 'cad-to-dagmc-mesher'. If not provided, backend is
                   auto-selected based on other arguments: tet_volumes or
                   target_edge_length select 'cad-to-dagmc-mesher', gmsh-specific
-                  arguments select 'gmsh'. Defaults to 'cadquery' if no
-                  backend-specific arguments are given.
+                  arguments select 'gmsh'. Defaults to 'cad-to-dagmc-mesher' if
+                  no backend-specific arguments are given, falling back to
+                  'cadquery' when cad-to-dagmc-mesher is not installed.
                 - h5m_backend (str, optional): 'pymoab' or 'h5py' for writing h5m files.
                   Defaults to 'h5py'.
 
@@ -2042,8 +2043,28 @@ class CadToDagmc:
                 meshing_backend = "cad-to-dagmc-mesher"
             elif has_gmsh:
                 meshing_backend = "gmsh"
+            elif _cad_to_dagmc_mesher_is_available():
+                meshing_backend = "cad-to-dagmc-mesher"  # default
             else:
-                meshing_backend = "cadquery"  # default
+                # cad-to-dagmc-mesher is a dependency of the pip package but is
+                # not on conda-forge, so a conda installation can be without it.
+                # A call that names no backend at all has expressed no
+                # preference, so fall back to cadquery, which is always present,
+                # rather than failing. Warn so the substitution is visible and
+                # so the remedy is to hand, since pip installing the mesher
+                # works alongside a conda installation.
+                warnings.warn(
+                    "No meshing backend was given so the cad-to-dagmc-mesher "
+                    "backend would be used, but cad-to-dagmc-mesher is not "
+                    "installed. Falling back to the cadquery backend. "
+                    "cad-to-dagmc-mesher is not available on conda-forge, "
+                    "install it with pip, which works alongside a conda "
+                    "installation:\n"
+                    "  pip install cad-to-dagmc-mesher\n\n"
+                    "Pass meshing_backend='cadquery' to select the cadquery "
+                    "backend explicitly and silence this warning."
+                )
+                meshing_backend = "cadquery"
 
         # Validate meshing backend
         if meshing_backend not in ["gmsh", "cadquery", "cad-to-dagmc-mesher"]:

--- a/tests/test_kwarg_args.py
+++ b/tests/test_kwarg_args.py
@@ -274,22 +274,28 @@ class TestKwargsExportDagmcH5mFile:
         assert result == str(output_file)
         assert output_file.exists()
 
-    def test_no_backend_args_without_mesher_installed_still_works(
-        self, tmp_path, monkeypatch
+    def test_no_backend_args_without_mesher_installed_falls_back_to_cadquery(
+        self, tmp_path, monkeypatch, capsys
     ):
-        """A plain export must not be affected by the mesher being absent."""
+        """A plain export must not be affected by the mesher being absent.
+
+        cad-to-dagmc-mesher is not on conda-forge, so a call that names no
+        backend has to keep working without it rather than raising.
+        """
         monkeypatch.setattr(
             "cad_to_dagmc.core._cad_to_dagmc_mesher_is_available", lambda: False
         )
         output_file = tmp_path / "default_no_mesher.h5m"
 
-        result = self.my_model.export_dagmc_h5m_file(filename=str(output_file))
+        with pytest.warns(UserWarning, match="Falling back to the cadquery backend"):
+            result = self.my_model.export_dagmc_h5m_file(filename=str(output_file))
 
         assert result == str(output_file)
         assert output_file.exists()
+        assert "Using meshing backend: cadquery" in capsys.readouterr().out
 
-    def test_no_backend_args_still_default_to_cadquery(self, tmp_path):
-        """With no backend selecting arguments the cadquery default stands."""
+    def test_no_backend_args_default_to_cad_to_dagmc_mesher(self, tmp_path, capsys):
+        """With no backend selecting arguments the mesher is chosen."""
         output_file = tmp_path / "auto_default.h5m"
 
         with warnings.catch_warnings(record=True) as w:
@@ -299,6 +305,9 @@ class TestKwargsExportDagmcH5mFile:
 
         assert result == str(output_file)
         assert output_file.exists()
+        assert "Using meshing backend: cad-to-dagmc-mesher" in capsys.readouterr().out
+        # Naming no backend expresses no preference, so there is nothing to
+        # disambiguate and nothing to warn about.
         assert not [
             warning
             for warning in w


### PR DESCRIPTION
## What

`export_dagmc_h5m_file` with no meshing backend and no backend-specific arguments now selects `cad-to-dagmc-mesher` instead of `cadquery`.

## Why

The zero-config path was cadquery, which is the one backend affected by shared face handling in `cadquery_direct_mesh_plugin` 0.2.0. That release gives an imprinted shared face a different id in each solid, so the interface between two touching solids is written as two coincident one-sided surfaces instead of one surface shared by both volumes.

The effect is silent. On `TwoTouchingCuboids` the h5m has 12 surfaces with no shared interface, where it should have 11 with one. There are no lost particle messages, just a track length flux in the neighbouring material that is low by 15 to 37 percent in multi-solid models. Every single-solid model is unaffected, which is why this went unnoticed.

The other two backends imprint correctly, so moving the default off cadquery removes the exposure for anyone who has not chosen a backend.

## Fallback

`cad-to-dagmc-mesher` is a dependency of the pip package but is not on conda-forge, so a conda installation can be without it. A call that names no backend has expressed no preference and should not hard fail, so it falls back to cadquery and warns, pointing at the pip install that works alongside a conda installation.

The `tolerance`-only path is unchanged and still raises `CadToDagmcMesherNotFoundError`. The asymmetry is deliberate: there the caller expressed a preference that two backends could satisfy, here they expressed none.

## Tests

- `test_no_backend_args_still_default_to_cadquery` renamed to `test_no_backend_args_default_to_cad_to_dagmc_mesher`, now asserting on the selected backend rather than only that the file was written
- `test_no_backend_args_without_mesher_installed_still_works` renamed to `..._falls_back_to_cadquery`, now asserting the warning fires and cadquery is selected
- full suite passes (196 passed, 2 skipped, `test_mesh_to_dagmc.py` needs `assembly-mesh-plugin` which is not installed locally)
- verified end to end against the released stack with the affected plugin 0.2.0 installed: the no-argument call now writes 11 surfaces with one shared interface

## Docs

`meshing/index.md` moves the default label onto cad-to-dagmc-mesher and documents the conda-forge fallback. `gmsh_backend.md` and `quickstart.md` both described GMSH as the default, which was already incorrect before this change, so those claims are corrected too.