### PR TITLE
Share the face id of a face that two touching solids share

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -158,6 +158,94 @@ def imprint_assembly(assembly):
     return imprint(assembly)
 
 
+def share_coincident_face_ids(triangles_by_solid_by_face):
+    """Give the face two touching solids share a single id in both of them.
+
+    Imprinting leaves one face between two touching solids, but
+    cadquery_direct_mesh_plugin numbers faces per solid, so depending on the
+    installed version each solid can contribute its own id for that one face.
+    Writing both produces two coincident one sided DAGMC surfaces instead of
+    one surface carrying a sense for each volume, which does not transport
+    correctly: particles crossing the interface are not handed to the
+    neighbouring volume, and the flux tallied there comes out low with nothing
+    reported.
+
+    The plugin welds vertices across the whole assembly, so both copies of the
+    interface index the same vertices and differ only in winding. Keying on the
+    triangle set with each triangle sorted is therefore orientation insensitive
+    and identifies the copies. Only the ids are rewritten. Each solid keeps its
+    own winding under the shared id, which is what vertices_to_h5m expects: it
+    writes the surface once from the first solid that refers to it and reads
+    the second solid off the shared id to build GEOM_SENSE_2.
+
+    Ids are handed out from 1 in order of first appearance rather than the
+    plugin's original ids being kept. Merging without renumbering would leave
+    the ids of the dropped copies unused, so the highest surface id would stay
+    as high as the unmerged count. Those ids become DAGMC surface ids, and a
+    DAGMC universe embedded in CSG shares an id space with the CSG surfaces, so
+    an inflated range collides with them ("Surface ID 21 exists in both
+    Universe 3 and the CSG geometry"). Renumbering also matches what gmsh and
+    cad-to-dagmc-mesher produce.
+
+    This reproduces what the plugin does when it shares imprinted face ids
+    itself (jmwright/cadquery-direct-mesh-plugin#10), including the numbering.
+    It is idempotent, so it is a no-op against a plugin that already shares
+    them. Once that pull request is released AND the
+    cadquery_direct_mesh_plugin floor in pyproject.toml is raised to that
+    release, this function and its call can be removed. Removing it before the
+    floor is raised would reintroduce the bug for anyone on an older plugin.
+
+    Args:
+        triangles_by_solid_by_face: Dict mapping solid_id -> face_id -> list of
+            triangles, each triangle a list of vertex indices.
+
+    Returns:
+        The same mapping with coincident faces sharing one face id, and ids
+        renumbered contiguously from 1.
+
+    Raises:
+        ValueError: if a face is shared by more than two solids, or if one
+            solid carries the same face twice. Neither is representable as
+            DAGMC geometry, and vertices_to_h5m would silently write a wrong
+            sense rather than fail.
+    """
+
+    def canonical(triangles):
+        return frozenset(tuple(sorted(int(vertex) for vertex in triangle))
+                         for triangle in triangles)
+
+    id_by_key = {}
+    solid_ids_by_key = {}
+    remapped = {}
+    for solid_id, faces in triangles_by_solid_by_face.items():
+        shared_faces = {}
+        for triangles in faces.values():
+            key = canonical(triangles)
+            solid_ids_by_key.setdefault(key, []).append(solid_id)
+            if key not in id_by_key:
+                id_by_key[key] = len(id_by_key) + 1
+            shared_faces[id_by_key[key]] = triangles
+        remapped[solid_id] = shared_faces
+
+    for key, solid_ids in solid_ids_by_key.items():
+        if len(solid_ids) != len(set(solid_ids)):
+            msg = (
+                f"Solid {solid_ids[0]} has the same face twice, so it cannot be "
+                "written as DAGMC geometry. This points at a degenerate or zero "
+                "thickness feature in the CAD."
+            )
+            raise ValueError(msg)
+        if len(solid_ids) > 2:
+            msg = (
+                f"The face with id {id_by_key[key]} is shared by solids "
+                f"{sorted(solid_ids)}. A DAGMC surface separates at most two "
+                "volumes, so this points at overlapping solids in the CAD."
+            )
+            raise ValueError(msg)
+
+    return remapped
+
+
 def define_moab_core_and_tags():
     """Creates a MOAB Core instance which can be built up by adding sets of
     triangles to the instance
@@ -2183,6 +2271,10 @@ class CadToDagmc:
                 # Extract the mesh information to allow export to h5m from the direct-mesh result
                 vertices = cq_mesh["vertices"]
                 triangles_by_solid_by_face = cq_mesh["solid_face_triangle_vertex_map"]
+                if imprint:
+                    triangles_by_solid_by_face = share_coincident_face_ids(
+                        triangles_by_solid_by_face
+                    )
             # Use gmsh
             elif meshing_backend == "gmsh":
                 # If assembly is not to be imprinted, pass through the assembly as-is

--- a/tests/test_share_coincident_face_ids.py
+++ b/tests/test_share_coincident_face_ids.py
@@ -1,0 +1,213 @@
+"""Tests for sharing the face id of a face that two touching solids share.
+
+cadquery_direct_mesh_plugin numbers faces per solid, so depending on the
+installed version the one face between two touching solids can arrive as two
+ids, one per solid. share_coincident_face_ids puts them back onto a single id
+so the h5m gets one surface with a sense for each volume rather than two
+coincident one sided surfaces.
+"""
+
+import cadquery as cq
+import pytest
+
+from cad_to_dagmc import CadToDagmc
+from cad_to_dagmc.core import share_coincident_face_ids
+
+# Two unit cubes touching on the plane x=1, meshed as two triangles per face
+# over welded vertices. Face 4 of solid 1 and face 10 of solid 2 are the same
+# face, wound in opposite directions.
+TOUCHING_CUBES_SPLIT_IDS = {
+    1: {
+        1: [[0, 1, 2], [1, 3, 2]],
+        4: [[4, 5, 6], [5, 7, 6]],
+    },
+    2: {
+        7: [[8, 9, 10], [9, 11, 10]],
+        10: [[6, 5, 4], [6, 7, 5]],
+    },
+}
+
+
+def _two_touching_boxes():
+    assembly = cq.Assembly()
+    assembly.add(cq.Workplane().box(10, 10, 10))
+    assembly.add(cq.Workplane().transformed(offset=(0, 7, 0)).box(10, 4, 10))
+    return assembly
+
+
+def _surface_ids_and_shared_count(h5m_filename):
+    """Return the surface global ids and how many surfaces bound two volumes."""
+    from pymoab import core, types
+
+    moab_core = core.Core()
+    moab_core.load_file(str(h5m_filename))
+    category_tag = moab_core.tag_get_handle(types.CATEGORY_TAG_NAME)
+    global_id_tag = moab_core.tag_get_handle(types.GLOBAL_ID_TAG_NAME)
+
+    surface_ids = []
+    shared = 0
+    for entity in moab_core.get_entities_by_type(
+        moab_core.get_root_set(), types.MBENTITYSET
+    ):
+        try:
+            category = moab_core.tag_get_data(category_tag, entity, flat=True)[0]
+        except Exception:
+            continue
+        if isinstance(category, bytes):
+            category = category.decode(errors="ignore")
+        if category.split("\x00")[0] != "Surface":
+            continue
+        surface_ids.append(int(moab_core.tag_get_data(global_id_tag, entity, flat=True)[0]))
+        if len(moab_core.get_parent_meshsets(entity)) == 2:
+            shared += 1
+    return sorted(surface_ids), shared
+
+
+def test_coincident_faces_get_one_id():
+    """The face both solids carry ends up under a single id."""
+    shared = share_coincident_face_ids(TOUCHING_CUBES_SPLIT_IDS)
+
+    assert set(shared[1]) & set(shared[2]), "no id is shared between the solids"
+    assert len(set(shared[1]) | set(shared[2])) == 3, "expected 3 distinct faces"
+
+
+def test_each_solid_keeps_its_own_winding():
+    """Only ids are rewritten, the triangles are handed through untouched.
+
+    vertices_to_h5m writes the surface from the first solid that refers to it,
+    so the second solid's opposite winding must survive rather than be
+    overwritten with a copy of the first.
+    """
+    shared = share_coincident_face_ids(TOUCHING_CUBES_SPLIT_IDS)
+    shared_id = (set(shared[1]) & set(shared[2])).pop()
+
+    assert shared[1][shared_id] == TOUCHING_CUBES_SPLIT_IDS[1][4]
+    assert shared[2][shared_id] == TOUCHING_CUBES_SPLIT_IDS[2][10]
+
+
+def test_is_idempotent():
+    """A mapping that already shares ids is returned unchanged.
+
+    This is what a plugin carrying jmwright/cadquery-direct-mesh-plugin#10
+    produces, so the call has to be a no-op against it.
+    """
+    already_shared = share_coincident_face_ids(TOUCHING_CUBES_SPLIT_IDS)
+
+    assert share_coincident_face_ids(already_shared) == already_shared
+
+
+def test_face_shared_by_three_solids_raises():
+    """A DAGMC surface separates at most two volumes."""
+    face = [[0, 1, 2]]
+    with pytest.raises(ValueError, match="shared by solids"):
+        share_coincident_face_ids({1: {1: face}, 2: {2: face}, 3: {3: face}})
+
+
+def test_same_face_twice_on_one_solid_raises():
+    """A solid carrying the same face twice is degenerate geometry."""
+    with pytest.raises(ValueError, match="same face twice"):
+        share_coincident_face_ids({1: {1: [[0, 1, 2]], 2: [[2, 1, 0]]}})
+
+
+def test_distinct_faces_keep_distinct_ids():
+    """Faces that are not coincident are not merged."""
+    separate = {1: {1: [[0, 1, 2]]}, 2: {2: [[3, 4, 5]]}}
+    shared = share_coincident_face_ids(separate)
+
+    assert not set(shared[1]) & set(shared[2])
+
+
+def test_ids_are_contiguous_from_one():
+    """Merging must not leave the dropped copies' ids unused.
+
+    Face ids become DAGMC surface ids, and a DAGMC universe embedded in CSG
+    shares an id space with the CSG surfaces, so an id range inflated by gaps
+    collides with them. Renumbering keeps the range as small as the surface
+    count.
+    """
+    shared = share_coincident_face_ids(TOUCHING_CUBES_SPLIT_IDS)
+
+    all_ids = set()
+    for faces in shared.values():
+        all_ids |= set(faces)
+    assert all_ids == set(range(1, len(all_ids) + 1))
+
+
+def test_cadquery_backend_writes_one_shared_surface(tmp_path):
+    """End to end: the interface is one surface bounding two volumes.
+
+    Two touching boxes have 11 distinct faces. Without sharing, the interface
+    is written twice and the file has 12 surfaces, none of which bounds two
+    volumes.
+    """
+    pytest.importorskip("pymoab")
+
+    model = CadToDagmc()
+    model.add_cadquery_object(_two_touching_boxes(), material_tags=["mat1", "mat2"])
+    h5m_filename = tmp_path / "touching_boxes.h5m"
+
+    model.export_dagmc_h5m_file(
+        filename=str(h5m_filename),
+        meshing_backend="cadquery",
+        tolerance=0.1,
+        angular_tolerance=0.1,
+    )
+
+    surface_ids, shared = _surface_ids_and_shared_count(h5m_filename)
+    assert len(surface_ids) == 11
+    assert shared == 1
+
+
+def test_three_solids_get_contiguous_surface_ids(tmp_path):
+    """Three solids meeting on several faces must not inflate the id range.
+
+    A gap left where a merged id was pushes the highest surface id above the
+    surface count, and OpenMC then rejects the model because a DAGMC universe
+    embedded in CSG shares an id space with the CSG surfaces.
+    """
+    pytest.importorskip("pymoab")
+
+    assembly = cq.Assembly()
+    assembly.add(cq.Workplane().box(10, 10, 10))
+    assembly.add(cq.Workplane().transformed(offset=(0, 7, 0)).box(10, 4, 10))
+    assembly.add(cq.Workplane().transformed(offset=(0, 0, 7)).box(10, 10, 4))
+
+    model = CadToDagmc()
+    model.add_cadquery_object(assembly, material_tags=["mat1", "mat2", "mat3"])
+    h5m_filename = tmp_path / "three_boxes.h5m"
+
+    model.export_dagmc_h5m_file(
+        filename=str(h5m_filename),
+        meshing_backend="cadquery",
+        tolerance=0.1,
+        angular_tolerance=0.1,
+    )
+
+    surface_ids, shared = _surface_ids_and_shared_count(h5m_filename)
+    assert surface_ids == list(range(1, len(surface_ids) + 1))
+    assert shared == 2
+
+
+def test_unimprinted_export_is_unaffected(tmp_path):
+    """Without imprinting the solids are separate and share no face.
+
+    The vertices are not welded either, so there is nothing to merge and the
+    interface is legitimately written twice.
+    """
+    pytest.importorskip("pymoab")
+
+    model = CadToDagmc()
+    model.add_cadquery_object(_two_touching_boxes(), material_tags=["mat1", "mat2"])
+    h5m_filename = tmp_path / "touching_boxes_unimprinted.h5m"
+
+    model.export_dagmc_h5m_file(
+        filename=str(h5m_filename),
+        meshing_backend="cadquery",
+        imprint=False,
+        tolerance=0.1,
+        angular_tolerance=0.1,
+    )
+
+    surface_ids, shared = _surface_ids_and_shared_count(h5m_filename)
+    assert len(surface_ids) == 12
+    assert shared == 0


### PR DESCRIPTION
## What

The cadquery backend now gives the one face between two touching solids a single face id in both solids, instead of writing each solid's copy as its own DAGMC surface.

Independent of #208 and can merge in either order.

## Why

Imprinting leaves one face between two touching solids, but `cadquery_direct_mesh_plugin` numbers faces per solid, so depending on the installed version each solid contributes its own id for that one face. Released plugin 0.2.0 does exactly that.

The h5m then gets two coincident one-sided surfaces where it should have one surface carrying a sense for each volume. Particles crossing the interface are not handed to the neighbouring volume, so the flux tallied there comes out low. It is silent: no lost particle messages, just a wrong answer. Only multi-solid models are affected, which is why it went unnoticed.

On `TwoTouchingCuboids` the file has 12 surfaces with none bounding two volumes, where it should have 11 with one.

## How

The plugin welds vertices across the whole assembly even when it does not share the ids, so both copies of the interface index the same vertices and differ only in winding. Keying on the triangle set with each triangle sorted is orientation insensitive and identifies them.

Only the ids are rewritten. Each solid keeps its own winding under the shared id, which is what `vertices_to_h5m` expects: it writes the surface once from the first solid that refers to it and reads the second solid off the shared id to build `GEOM_SENSE_2`.

Ids are handed out from 1 in order of first appearance rather than the original ids being kept. Merging without renumbering leaves the dropped copies' ids unused, so the highest surface id stays as high as the unmerged count. Those become DAGMC surface ids, and a DAGMC universe embedded in CSG shares an id space with the CSG surfaces, so an inflated range is rejected with `Surface ID 21 exists in both Universe 3 and the CSG geometry`. This was caught by a three-solid model and is covered by a test.

## Relationship to the plugin

This reproduces what the plugin does when it shares imprinted face ids itself (jmwright/cadquery-direct-mesh-plugin#10), including the numbering, so it is a no-op against a plugin that already does. It can be removed once that pull request is released **and** the `cadquery_direct_mesh_plugin` floor in `pyproject.toml` is raised to that release. Removing it before the floor is raised would reintroduce the bug for anyone on an older plugin.

## Tests

New `tests/test_share_coincident_face_ids.py`: coincident faces get one id, each solid keeps its own winding, idempotence, contiguous numbering, a face shared by three solids raises, the same face twice on one solid raises, and end to end checks on two-solid and three-solid geometry plus the unimprinted path.

Verified against both plugin versions:

- full suite with released plugin 0.2.0: 206 passed, 2 skipped
- full suite with a plugin that already shares ids: 206 passed, 2 skipped
- the end to end test fails without the fix and passes with it, so it is not vacuous
- the 23 model_benchmark_zoo CAD versus CSG comparisons that fail on the cadquery backend all pass with plugin 0.2.0 and this change

`tests/test_mesh_to_dagmc.py` was excluded from those runs because `assembly-mesh-plugin` is not installed locally, which is unrelated to this change.