### PR TITLE
Allow the imprint argument to take a thread count

### DIFF
--- a/docs/advanced/imprinting.md
+++ b/docs/advanced/imprinting.md
@@ -36,6 +36,22 @@ model.export_dagmc_h5m_file(
 )
 ```
 
+## Limiting the Threads Used by Imprinting
+
+Imprinting runs in parallel and its peak RAM scales with the number of threads. Large models can run out of memory when imprinting on all cores, so a positive int can be passed instead of `True` to imprint with that many threads:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    imprint=1,  # imprint on a single thread, the lowest peak RAM
+)
+```
+
+`imprint=1` uses the least memory and is the slowest, `imprint=True` uses all available cores and is the fastest. Values in between trade the two off, for example `imprint=4`.
+
+The thread count is restored once the imprint is done, so the cadquery operations that follow are not limited. Note that `imprint=0` is not accepted: `0` cannot be told apart from `False` in Python, so use `imprint=False` to turn imprinting off.
+
 ## When to Disable Imprinting
 
 **Safe to disable when:**
@@ -51,6 +67,8 @@ model.export_dagmc_h5m_file(
 ## Performance Considerations
 
 Imprinting can be computationally expensive for complex geometries with many touching volumes. Disabling it may speed up mesh generation, but only do so if you're certain volumes don't share surfaces.
+
+Peak RAM is usually the limit rather than time. If imprinting runs out of memory, lower the thread count with `imprint=1` before reaching for `imprint=False`, which changes the resulting geometry.
 
 ## Imprinting and Material Tag Order
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -34,6 +34,7 @@ model.export_dagmc_h5m_file(
 |--------|-------------|
 | `scale_factor` | CAD in different units than simulation |
 | `imprint=False` | Single volume or non-touching geometry |
+| `imprint=1` | Imprinting runs out of RAM on a large model |
 | `implicit_complement_material_tag` | Need to track particles in void |
 | `h5m_backend="pymoab"` | Compatibility with older DAGMC tools |
 | `method="inMemory"` | Large geometry with matching OCC versions |

--- a/docs/advanced/parallel_processing.md
+++ b/docs/advanced/parallel_processing.md
@@ -8,9 +8,23 @@ Both CadQuery and GMSH use parallel processing for operations like imprinting an
 - **Memory constraints**: Each thread requires memory; fewer threads = lower peak memory
 - **Debugging**: Single-threaded execution can make errors easier to diagnose
 
+## Limiting Imprinting Threads
+
+Imprinting is usually the most memory hungry parallel step. The export methods take the thread count directly on the `imprint` argument, so there is no need to change any global setting:
+
+<!--pytest-codeblocks:skip-->
+```python
+model.export_dagmc_h5m_file(
+    filename="dagmc.h5m",
+    imprint=1,  # imprint on a single thread, the lowest peak RAM
+)
+```
+
+The previous thread count is restored once the imprint is done. See [Imprinting](imprinting.md) for details.
+
 ## Limiting CadQuery Threads
 
-CadQuery provides a `setThreads` function:
+To limit every CadQuery operation rather than just the imprint, CadQuery provides a `setThreads` function:
 
 <!--pytest-codeblocks:skip-->
 ```python
@@ -83,6 +97,7 @@ gmsh.option.setNumber("Mesh.MaxNumThreads3D", 4)
 
 | Component | Method | When Applied |
 |-----------|--------|--------------|
+| Imprinting | `imprint=<int>` export argument | For the duration of the imprint only |
 | CadQuery | `setThreads()` | Any time before operations |
 | CadQuery | `OSD_ThreadPool.DefaultPool_s()` | Before importing CadQuery |
 | CadQuery | `OMP_NUM_THREADS` env var | Before Python starts |

--- a/docs/outputs/dagmc_h5m.md
+++ b/docs/outputs/dagmc_h5m.md
@@ -87,7 +87,7 @@ model.export_dagmc_h5m_file(
 |-----------|------|---------|-------------|
 | `filename` | str | "dagmc.h5m" | Output file path |
 | `scale_factor` | float | 1.0 | Geometry scale factor |
-| `imprint` | bool | True | Imprint shared surfaces |
+| `imprint` | bool or int | True | Imprint shared surfaces. An int limits the imprint to that many threads |
 | `implicit_complement_material_tag` | str | None | Void space material tag |
 
 **Backend Selection:**

--- a/docs/outputs/gmsh_mesh.md
+++ b/docs/outputs/gmsh_mesh.md
@@ -91,7 +91,7 @@ model.export_gmsh_mesh_file(
 | `mesh_algorithm` | int | 1 | GMSH meshing algorithm |
 | `set_size` | dict | None | Per-volume mesh sizes |
 | `scale_factor` | float | 1.0 | Geometry scale factor |
-| `imprint` | bool | True | Imprint shared surfaces |
+| `imprint` | bool or int | True | Imprint shared surfaces. An int limits the imprint to that many threads |
 | `method` | str | "file" | CAD transfer method |
 
 ## Use Cases

--- a/docs/outputs/unstructured_vtk.md
+++ b/docs/outputs/unstructured_vtk.md
@@ -165,7 +165,7 @@ model.export_unstructured_mesh_file(
 | `set_size` | dict | None | Per-volume mesh sizes (gmsh) |
 | `volumes` | list | None | Specific volumes to mesh (gmsh) |
 | `scale_factor` | float | 1.0 | Geometry scale factor |
-| `imprint` | bool | True | Imprint shared surfaces |
+| `imprint` | bool or int | True | Imprint shared surfaces. An int limits the imprint to that many threads |
 | `method` | str | "file" | CAD transfer method (gmsh) |
 | `meshing_backend` | str | None | "gmsh" or "cad-to-dagmc-mesher"; auto-selected when not set |
 | `target_edge_length` | float | None | Tetrahedron edge length (cad-to-dagmc-mesher) |

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable
 import importlib.util
@@ -6,6 +7,8 @@ import gmsh
 import numpy as np
 from cadquery import importers
 from cadquery.occ_impl.importers.assembly import importStep as importStepAssembly
+from cadquery.occ_impl.shapes import setThreads
+from OCP.OSD import OSD_ThreadPool
 import tempfile
 import warnings
 from typing import Iterable
@@ -126,7 +129,76 @@ def combine_tet_meshes(tet_data):
     return np.vstack(all_vertices), np.vstack(all_tetrahedra)
 
 
-def imprint_assembly(assembly):
+def resolve_imprint(imprint: bool | int) -> tuple[bool, int | None]:
+    """Split the imprint argument into a flag and a thread limit.
+
+    The imprint argument of the export methods accepts either a bool or an
+    int. True imprints with however many threads the OpenCASCADE thread pool
+    is set to (all cores unless the caller has already limited it), False
+    skips imprinting, and a positive int imprints with that many threads.
+    Imprinting runs in parallel and its peak RAM scales with the number of
+    threads, so a large model that runs out of memory can often be imprinted
+    by lowering the thread count.
+
+    Args:
+        imprint: the imprint argument as given by the user.
+
+    Returns:
+        (do_imprint, threads) where threads is None when the thread count is
+        to be left as the caller set it.
+
+    Raises:
+        ValueError: if an int less than 1 is given.
+        TypeError: if something other than a bool or an int is given.
+    """
+    # bool is a subclass of int so it has to be tested for first. It also
+    # means an int cannot express "do not imprint": imprint=0 would be
+    # indistinguishable from imprint=False, so 0 is rejected rather than
+    # guessed at.
+    if isinstance(imprint, bool):
+        return imprint, None
+    if isinstance(imprint, int):
+        if imprint < 1:
+            raise ValueError(
+                f"imprint={imprint} is not a valid number of threads. Use "
+                "imprint=False to skip imprinting, imprint=True to imprint "
+                "with all available cores, or a positive int to imprint with "
+                "that many threads."
+            )
+        return True, imprint
+    raise TypeError(
+        f"imprint must be a bool or an int, got {type(imprint).__name__}. Use "
+        "imprint=True or imprint=False to turn imprinting on or off, or a "
+        "positive int to imprint with that many threads."
+    )
+
+
+@contextmanager
+def thread_limit(threads: int | None):
+    """Limit the threads OpenCASCADE uses, restoring the limit afterwards.
+
+    cadquery's setThreads sets the size of the OpenCASCADE thread pool that
+    the boolean operations behind imprinting run on. The pool is process wide,
+    so the previous size is put back on the way out and the cadquery
+    operations that follow are left running on as many threads as before.
+
+    Args:
+        threads: the number of threads to allow, or None to leave the pool
+            alone.
+    """
+    if threads is None:
+        yield
+        return
+
+    previous = OSD_ThreadPool.DefaultPool_s().NbThreads()
+    setThreads(threads)
+    try:
+        yield
+    finally:
+        setThreads(previous)
+
+
+def imprint_assembly(assembly, threads: int | None = None):
     """Imprint a CadQuery assembly into a connected compound.
 
     Uses the BOPAlgo_Builder based imprint with glue="partial" when the
@@ -134,6 +206,12 @@ def imprint_assembly(assembly):
     lower RAM than the older BOPAlgo_MakeConnected based imprint, with the
     same result for touching, non-overlapping solids). Older cadquery
     versions fall back to the original single-argument imprint.
+
+    Args:
+        assembly: the cadquery assembly to imprint.
+        threads: the number of threads to imprint with. Fewer threads lowers
+            the peak RAM of the imprint at the cost of speed. Defaults to None
+            which leaves the thread count as it is.
 
     Returns:
         (imprinted_shape, imprinted_solids_with_original_ids)
@@ -152,10 +230,11 @@ def imprint_assembly(assembly):
         compound = cq.occ_impl.shapes.Compound.makeCompound(solids)
         return compound, {s: (id_map[s],) for s in solids}
 
-    imprint = cq.occ_impl.assembly.imprint
-    if "glue" in inspect.signature(imprint).parameters:
-        return imprint(assembly, glue="partial")
-    return imprint(assembly)
+    with thread_limit(threads):
+        imprint = cq.occ_impl.assembly.imprint
+        if "glue" in inspect.signature(imprint).parameters:
+            return imprint(assembly, glue="partial")
+        return imprint(assembly)
 
 
 def share_coincident_face_ids(triangles_by_solid_by_face):
@@ -1609,7 +1688,7 @@ class CadToDagmc:
         mesh_algorithm: int = 1,
         method: str = "file",
         scale_factor: float = 1.0,
-        imprint: bool = True,
+        imprint: bool | int = True,
         set_size: dict[int | str, float] | None = None,
         volumes: Iterable[int] | None = None,
         threads: int = 0,
@@ -1656,7 +1735,12 @@ class CadToDagmc:
             imprint: whether to imprint the geometry or not. Defaults to True as this is
                 normally needed to ensure the geometry is meshed correctly. However if
                 you know your geometry does not need imprinting you can set this to False
-                and this can save time.
+                and this can save time. A positive int can be passed instead of True to
+                imprint with that many threads, for example imprint=1 imprints on a
+                single thread. Imprinting runs in parallel and its peak RAM scales with
+                the number of threads, so fewer threads lowers the peak RAM of large
+                models at the cost of speed. The thread count is restored afterwards so
+                the cadquery operations that follow are unaffected.
             set_size: a dictionary mapping volume IDs (int) or material tag names
                 (str) to target mesh sizes (floats). Material tags are resolved to
                 all volume IDs that have that tag. Only used by the gmsh backend.
@@ -1692,6 +1776,8 @@ class CadToDagmc:
         if Path(filename).suffix != ".vtk":
             raise ValueError("Unstructured mesh filename must have a .vtk extension")
 
+        imprint, imprint_threads = resolve_imprint(imprint)
+
         if meshing_backend is None:
             # Auto-select the backend: the tet arguments are specific to
             # cad-to-dagmc-mesher, everything else defaults to gmsh.
@@ -1715,6 +1801,7 @@ class CadToDagmc:
                 tolerance=tolerance,
                 angular_tolerance=angular_tolerance,
                 imprint=imprint,
+                imprint_threads=imprint_threads,
                 scale_factor=scale_factor,
             )
 
@@ -1724,7 +1811,7 @@ class CadToDagmc:
 
         if imprint:
             print("Imprinting assembly for unstructured mesh generation")
-            imprinted_assembly, _ = imprint_assembly(assembly)
+            imprinted_assembly, _ = imprint_assembly(assembly, threads=imprint_threads)
         else:
             imprinted_assembly = assembly
 
@@ -1796,6 +1883,7 @@ class CadToDagmc:
         tolerance: float,
         angular_tolerance: float,
         imprint: bool,
+        imprint_threads: int | None = None,
         scale_factor: float = 1.0,
     ) -> str:
         """Write an unstructured .vtk volume mesh using cad-to-dagmc-mesher.
@@ -1827,6 +1915,7 @@ class CadToDagmc:
             tet_volumes=tet_volumes,
             target_edge_length=target_edge_length,
             imprint=imprint,
+            imprint_threads=imprint_threads,
         )
 
         if not tet_data:
@@ -1854,7 +1943,7 @@ class CadToDagmc:
         dimensions: int = 2,
         method: str = "file",
         scale_factor: float = 1.0,
-        imprint: bool = True,
+        imprint: bool | int = True,
         set_size: dict[int | str, float] | None = None,
         threads: int = 0,
     ):
@@ -1882,7 +1971,12 @@ class CadToDagmc:
             imprint: whether to imprint the geometry or not. Defaults to True as this is
                 normally needed to ensure the geometry is meshed correctly. However if
                 you know your geometry does not need imprinting you can set this to False
-                and this can save time.
+                and this can save time. A positive int can be passed instead of True to
+                imprint with that many threads, for example imprint=1 imprints on a
+                single thread. Imprinting runs in parallel and its peak RAM scales with
+                the number of threads, so fewer threads lowers the peak RAM of large
+                models at the cost of speed. The thread count is restored afterwards so
+                the cadquery operations that follow are unaffected.
             set_size: a dictionary mapping volume IDs (int) or material tag names
                 (str) to target mesh sizes (floats). Material tags are resolved to
                 all volume IDs that have that tag.
@@ -1890,13 +1984,15 @@ class CadToDagmc:
                 available cores (default), 1 uses a single thread.
         """
 
+        imprint, imprint_threads = resolve_imprint(imprint)
+
         assembly = cq.Assembly()
         for part in self.parts:
             assembly.add(part)
 
         if imprint:
             print("Imprinting assembly for mesh generation")
-            imprinted_assembly, _ = imprint_assembly(assembly)
+            imprinted_assembly, _ = imprint_assembly(assembly, threads=imprint_threads)
         else:
             imprinted_assembly = assembly
 
@@ -1953,7 +2049,7 @@ class CadToDagmc:
         filename: str = "dagmc.h5m",
         implicit_complement_material_tag: str | None = None,
         scale_factor: float = 1.0,
-        imprint: bool = True,
+        imprint: bool | int = True,
         **kwargs,
     ) -> str:
         """Saves a DAGMC h5m file of the geometry
@@ -1963,7 +2059,13 @@ class CadToDagmc:
             implicit_complement_material_tag: the name of the material tag to use
                 for the implicit complement (void space).
             scale_factor: a scaling factor to apply to the geometry.
-            imprint: whether to imprint the geometry or not.
+            imprint: whether to imprint the geometry or not. A positive int can be
+                passed instead of True to imprint with that many threads, for example
+                imprint=1 imprints on a single thread. Imprinting runs in parallel and
+                its peak RAM scales with the number of threads, so fewer threads lowers
+                the peak RAM of large models at the cost of speed. The thread count is
+                restored afterwards so the cadquery operations that follow are
+                unaffected.
 
             **kwargs: Backend-specific parameters:
 
@@ -2015,6 +2117,8 @@ class CadToDagmc:
         Raises:
             ValueError: If invalid parameter combinations are used.
         """
+
+        imprint, imprint_threads = resolve_imprint(imprint)
 
         # Define all acceptable kwargs
         cadquery_keys = {"tolerance", "angular_tolerance"}
@@ -2263,13 +2367,16 @@ class CadToDagmc:
             # Use the CadQuery direct mesh plugin
             if meshing_backend == "cadquery":
                 import cadquery_direct_mesh_plugin
-                # Mesh the assembly using CadQuery's direct-mesh plugin
-                cq_mesh = assembly.toMesh(
-                    imprint=imprint,
-                    tolerance=tolerance,
-                    angular_tolerance=angular_tolerance,
-                    scale_factor=scale_factor,
-                )
+                # Mesh the assembly using CadQuery's direct-mesh plugin. The
+                # plugin imprints internally so the thread limit has to cover
+                # the whole call rather than just the imprint.
+                with thread_limit(imprint_threads):
+                    cq_mesh = assembly.toMesh(
+                        imprint=imprint,
+                        tolerance=tolerance,
+                        angular_tolerance=angular_tolerance,
+                        scale_factor=scale_factor,
+                    )
 
                 # Fix the material tag order for imprinted assemblies
                 if cq_mesh["imprinted_assembly"] is not None:
@@ -2302,7 +2409,7 @@ class CadToDagmc:
                 if imprint:
                     print("Imprinting assembly for mesh generation")
                     imprinted_assembly, imprinted_solids_with_org_id = (
-                        imprint_assembly(assembly)
+                        imprint_assembly(assembly, threads=imprint_threads)
                     )
 
                     scrambled_ids = get_ids_from_imprinted_assembly(
@@ -2387,6 +2494,7 @@ class CadToDagmc:
                         tet_volumes=tet_volumes_arg,
                         target_edge_length=target_edge_length,
                         imprint=imprint,
+                        imprint_threads=imprint_threads,
                     )
                 )
 
@@ -2475,7 +2583,7 @@ def _build_assembly(parts, scale_factor: float = 1.0):
 
 def _mesh_with_cad_to_dagmc_mesher(
     assembly, material_tags, tolerance, angular_tolerance,
-    tet_volumes, target_edge_length, imprint,
+    tet_volumes, target_edge_length, imprint, imprint_threads=None,
 ):
     """Mesh using cad-to-dagmc-mesher and return vertices_to_h5m-compatible output.
 
@@ -2490,15 +2598,18 @@ def _mesh_with_cad_to_dagmc_mesher(
     except ImportError as e:
         raise CadToDagmcMesherNotFoundError() from e
 
-    result = mesh_assembly(
-        assembly,
-        material_tags,
-        tolerance=tolerance,
-        angular_tolerance=angular_tolerance,
-        tet_volumes=tet_volumes,
-        target_edge_length=target_edge_length,
-        imprint=imprint,
-    )
+    # The mesher imprints internally so the thread limit has to cover the
+    # whole call rather than just the imprint.
+    with thread_limit(imprint_threads):
+        result = mesh_assembly(
+            assembly,
+            material_tags,
+            tolerance=tolerance,
+            angular_tolerance=angular_tolerance,
+            tet_volumes=tet_volumes,
+            target_edge_length=target_edge_length,
+            imprint=imprint,
+        )
     return (
         result["vertices"],
         result["triangles_by_solid_by_face"],

--- a/tests/test_imprint_threads.py
+++ b/tests/test_imprint_threads.py
@@ -1,0 +1,149 @@
+"""Tests for passing a thread count to the imprint argument.
+
+Imprinting runs in parallel and its peak RAM scales with the thread count, so
+the imprint argument accepts a positive int as well as a bool. The int limits
+the OpenCASCADE thread pool for the duration of the imprint and the previous
+limit is put back afterwards so other cadquery operations are unaffected.
+"""
+
+import cadquery as cq
+import pytest
+from OCP.OSD import OSD_ThreadPool
+
+from cad_to_dagmc import CadToDagmc
+from cad_to_dagmc.core import imprint_assembly, resolve_imprint, thread_limit
+
+
+def _pool_threads():
+    return OSD_ThreadPool.DefaultPool_s().NbThreads()
+
+
+def _two_touching_boxes():
+    assembly = cq.Assembly()
+    assembly.add(cq.Workplane().box(10, 10, 10))
+    assembly.add(cq.Workplane().transformed(offset=(0, 7, 0)).box(10, 4, 10))
+    return assembly
+
+
+def _model():
+    model = CadToDagmc()
+    model.add_cadquery_object(_two_touching_boxes(), material_tags=["mat1", "mat2"])
+    return model
+
+
+class TestResolveImprint:
+    def test_bools_leave_the_thread_count_alone(self):
+        assert resolve_imprint(True) == (True, None)
+        assert resolve_imprint(False) == (False, None)
+
+    def test_positive_int_imprints_with_that_many_threads(self):
+        assert resolve_imprint(1) == (True, 1)
+        assert resolve_imprint(4) == (True, 4)
+
+    @pytest.mark.parametrize("threads", [0, -1])
+    def test_int_below_one_is_rejected(self, threads):
+        """0 cannot mean off because bool is a subclass of int, so False and 0
+        would be the same argument."""
+        with pytest.raises(ValueError, match="not a valid number of threads"):
+            resolve_imprint(threads)
+
+    @pytest.mark.parametrize("imprint", ["2", 2.0, None])
+    def test_non_int_is_rejected(self, imprint):
+        with pytest.raises(TypeError, match="must be a bool or an int"):
+            resolve_imprint(imprint)
+
+
+class TestThreadLimit:
+    def test_limit_is_applied_and_restored(self):
+        before = _pool_threads()
+        with thread_limit(2):
+            assert _pool_threads() == 2
+        assert _pool_threads() == before
+
+    def test_limit_is_restored_after_an_exception(self):
+        before = _pool_threads()
+        with pytest.raises(RuntimeError):
+            with thread_limit(2):
+                raise RuntimeError("meshing failed")
+        assert _pool_threads() == before
+
+    def test_none_leaves_the_pool_alone(self):
+        before = _pool_threads()
+        with thread_limit(None):
+            assert _pool_threads() == before
+        assert _pool_threads() == before
+
+
+class TestImprintAssembly:
+    def test_threads_are_restored_after_imprinting(self):
+        before = _pool_threads()
+        imprint_assembly(_two_touching_boxes(), threads=1)
+        assert _pool_threads() == before
+
+    def test_thread_count_does_not_change_the_imprint(self):
+        """Fewer threads is a RAM and speed trade off, not a different result."""
+        all_threads, _ = imprint_assembly(_two_touching_boxes())
+        one_thread, _ = imprint_assembly(_two_touching_boxes(), threads=1)
+
+        assert len(one_thread.Solids()) == len(all_threads.Solids())
+        assert len(one_thread.Faces()) == len(all_threads.Faces())
+
+
+@pytest.mark.parametrize(
+    "meshing_backend", ["gmsh", "cadquery", "cad-to-dagmc-mesher"]
+)
+def test_export_dagmc_h5m_file_with_thread_limited_imprint(tmp_path, meshing_backend):
+    """Every backend accepts imprint=1 and leaves the thread pool as it found it."""
+    if meshing_backend == "cad-to-dagmc-mesher":
+        pytest.importorskip("cad_to_dagmc_mesher")
+
+    before = _pool_threads()
+    h5m_filename = tmp_path / f"{meshing_backend}.h5m"
+
+    _model().export_dagmc_h5m_file(
+        filename=str(h5m_filename),
+        meshing_backend=meshing_backend,
+        imprint=1,
+    )
+
+    assert h5m_filename.is_file()
+    assert _pool_threads() == before
+
+
+def test_export_gmsh_mesh_file_with_thread_limited_imprint(tmp_path):
+    before = _pool_threads()
+    msh_filename = tmp_path / "mesh.msh"
+
+    _model().export_gmsh_mesh_file(filename=str(msh_filename), imprint=2)
+
+    assert msh_filename.is_file()
+    assert _pool_threads() == before
+
+
+def test_export_unstructured_mesh_file_with_thread_limited_imprint(tmp_path):
+    before = _pool_threads()
+    vtk_filename = tmp_path / "umesh.vtk"
+
+    _model().export_unstructured_mesh_file(
+        filename=str(vtk_filename), meshing_backend="gmsh", imprint=2
+    )
+
+    assert vtk_filename.is_file()
+    assert _pool_threads() == before
+
+
+@pytest.mark.parametrize(
+    "export",
+    ["export_dagmc_h5m_file", "export_gmsh_mesh_file", "export_unstructured_mesh_file"],
+)
+def test_invalid_imprint_is_rejected_by_every_export(tmp_path, export):
+    """The argument is checked before any meshing so the failure is quick."""
+    filenames = {
+        "export_dagmc_h5m_file": "dagmc.h5m",
+        "export_gmsh_mesh_file": "mesh.msh",
+        "export_unstructured_mesh_file": "umesh.vtk",
+    }
+    method = getattr(_model(), export)
+
+    with pytest.raises(ValueError, match="not a valid number of threads"):
+        method(filename=str(tmp_path / filenames[export]), imprint=0)


### PR DESCRIPTION
Closes #210

Imprinting runs in parallel and its peak RAM scales with the number of threads, so a large model can run out of memory imprinting on all cores.

The `imprint` argument of `export_dagmc_h5m_file`, `export_gmsh_mesh_file` and `export_unstructured_mesh_file` now takes a positive int as well as a bool:

```python
model.export_dagmc_h5m_file(
    filename="dagmc.h5m",
    imprint=1,  # imprint on a single thread, the lowest peak RAM
)
```

`imprint=True` and `imprint=False` are unchanged.

## How it works

- `resolve_imprint(imprint)` splits the argument into `(do_imprint, threads)`. It runs before any meshing starts so an invalid value fails fast.
- `thread_limit(threads)` is a context manager that reads the current OpenCASCADE pool size, calls cadquery's `setThreads`, and restores the previous size in a `finally`. The pool is process wide, so restoring it leaves the cadquery operations that follow unlimited, including when meshing raises part way through.
- The gmsh backends call `imprint_assembly` directly, so there only the imprint is limited. The cadquery plugin and cad-to-dagmc-mesher imprint inside their own meshing calls, so for those the limit covers the whole call.

`bool` is a subclass of `int`, so an int cannot express "do not imprint": `imprint=0` would be indistinguishable from `imprint=False`. Ints below 1 are rejected with a `ValueError` pointing at `imprint=False`, and non-ints with a `TypeError`, rather than the value being guessed at.

## Testing

`tests/test_imprint_threads.py` covers argument resolution and rejection, the limit being applied and restored (including after an exception), the thread count not changing the imprint result, and every export method accepting a limited imprint and leaving the pool as it found it.

A 64 solid imprint takes 0.18 s on all cores and 0.31 s with `imprint=1`, producing identical topology (528 faces), which confirms the limit reaches the boolean operation rather than being ignored. Peak RSS does not separate at that size, so the memory saving follows from the thread count rather than being measured here.