### PR TITLE
Limit the imprint thread count to the imprint alone

### DIFF
--- a/docs/advanced/imprinting.md
+++ b/docs/advanced/imprinting.md
@@ -50,7 +50,7 @@ model.export_dagmc_h5m_file(
 
 `imprint=1` uses the least memory and is the slowest, `imprint=True` uses all available cores and is the fastest. Values in between trade the two off, for example `imprint=4`.
 
-The thread count is restored once the imprint is done, so the cadquery operations that follow are not limited. Note that `imprint=0` is not accepted: `0` cannot be told apart from `False` in Python, so use `imprint=False` to turn imprinting off.
+Only the imprint is limited. The meshing that follows it keeps all its threads on every backend, and the thread count is restored once the imprint is done so the cadquery operations that follow are not limited either. Note that `imprint=0` is not accepted: `0` cannot be told apart from `False` in Python, so use `imprint=False` to turn imprinting off.
 
 ## When to Disable Imprinting
 

--- a/docs/advanced/parallel_processing.md
+++ b/docs/advanced/parallel_processing.md
@@ -20,7 +20,7 @@ model.export_dagmc_h5m_file(
 )
 ```
 
-The previous thread count is restored once the imprint is done. See [Imprinting](imprinting.md) for details.
+Only the imprint is limited, the meshing keeps all its threads on every backend, and the previous thread count is restored once the imprint is done. See [Imprinting](imprinting.md) for details.
 
 ## Limiting CadQuery Threads
 

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable
+import functools
 import importlib.util
 import cadquery as cq
 import gmsh
@@ -196,6 +197,46 @@ def thread_limit(threads: int | None):
         yield
     finally:
         setThreads(previous)
+
+
+@contextmanager
+def imprint_thread_limit(threads: int | None):
+    """Limit the threads used by imprinting and by nothing else.
+
+    The gmsh backend imprints through imprint_assembly, so there the imprint
+    can simply be wrapped in thread_limit. The cadquery plugin and
+    cad-to-dagmc-mesher instead imprint part way through their own meshing
+    call, so wrapping that call would limit the meshing too, and the meshing
+    is not what runs out of memory.
+
+    Both of them reach the imprint through cq.occ_impl.assembly.imprint and
+    look it up when they call it, so swapping in a wrapper that shrinks the
+    pool around the real imprint keeps the limit on the imprint and off the
+    meshing either side of it. The original function is put back on the way
+    out, including when meshing raises part way through.
+
+    Args:
+        threads: the number of threads to imprint with, or None to leave the
+            pool alone.
+    """
+    if threads is None:
+        yield
+        return
+
+    real_imprint = cq.occ_impl.assembly.imprint
+
+    # functools.wraps keeps the signature intact: imprint_assembly and
+    # cad-to-dagmc-mesher both inspect it for the glue argument.
+    @functools.wraps(real_imprint)
+    def limited_imprint(*args, **kwargs):
+        with thread_limit(threads):
+            return real_imprint(*args, **kwargs)
+
+    cq.occ_impl.assembly.imprint = limited_imprint
+    try:
+        yield
+    finally:
+        cq.occ_impl.assembly.imprint = real_imprint
 
 
 def imprint_assembly(assembly, threads: int | None = None):
@@ -1739,8 +1780,10 @@ class CadToDagmc:
                 imprint with that many threads, for example imprint=1 imprints on a
                 single thread. Imprinting runs in parallel and its peak RAM scales with
                 the number of threads, so fewer threads lowers the peak RAM of large
-                models at the cost of speed. The thread count is restored afterwards so
-                the cadquery operations that follow are unaffected.
+                models at the cost of speed. Only the imprint is limited, the meshing
+                that follows it keeps all its threads whichever backend is used, and
+                the thread count is restored afterwards so the cadquery operations
+                that follow are unaffected.
             set_size: a dictionary mapping volume IDs (int) or material tag names
                 (str) to target mesh sizes (floats). Material tags are resolved to
                 all volume IDs that have that tag. Only used by the gmsh backend.
@@ -2063,9 +2106,10 @@ class CadToDagmc:
                 passed instead of True to imprint with that many threads, for example
                 imprint=1 imprints on a single thread. Imprinting runs in parallel and
                 its peak RAM scales with the number of threads, so fewer threads lowers
-                the peak RAM of large models at the cost of speed. The thread count is
-                restored afterwards so the cadquery operations that follow are
-                unaffected.
+                the peak RAM of large models at the cost of speed. Only the imprint is
+                limited, the meshing that follows it keeps all its threads whichever
+                backend is used, and the thread count is restored afterwards so the
+                cadquery operations that follow are unaffected.
 
             **kwargs: Backend-specific parameters:
 
@@ -2368,9 +2412,9 @@ class CadToDagmc:
             if meshing_backend == "cadquery":
                 import cadquery_direct_mesh_plugin
                 # Mesh the assembly using CadQuery's direct-mesh plugin. The
-                # plugin imprints internally so the thread limit has to cover
-                # the whole call rather than just the imprint.
-                with thread_limit(imprint_threads):
+                # plugin imprints internally, so the limit is put on the
+                # imprint itself and the tessellation keeps all its threads.
+                with imprint_thread_limit(imprint_threads):
                     cq_mesh = assembly.toMesh(
                         imprint=imprint,
                         tolerance=tolerance,
@@ -2598,9 +2642,9 @@ def _mesh_with_cad_to_dagmc_mesher(
     except ImportError as e:
         raise CadToDagmcMesherNotFoundError() from e
 
-    # The mesher imprints internally so the thread limit has to cover the
-    # whole call rather than just the imprint.
-    with thread_limit(imprint_threads):
+    # The mesher imprints internally, so the limit is put on the imprint
+    # itself and the meshing keeps all its threads.
+    with imprint_thread_limit(imprint_threads):
         result = mesh_assembly(
             assembly,
             material_tags,

--- a/tests/test_imprint_threads.py
+++ b/tests/test_imprint_threads.py
@@ -2,16 +2,26 @@
 
 Imprinting runs in parallel and its peak RAM scales with the thread count, so
 the imprint argument accepts a positive int as well as a bool. The int limits
-the OpenCASCADE thread pool for the duration of the imprint and the previous
-limit is put back afterwards so other cadquery operations are unaffected.
+the OpenCASCADE thread pool while the imprint runs and the previous limit is
+put back afterwards so other cadquery operations are unaffected. The limit is
+on the imprint alone: the meshing that follows it keeps all its threads, which
+takes some care for the cadquery and cad-to-dagmc-mesher backends because they
+imprint part way through their own meshing call.
 """
+
+import functools
 
 import cadquery as cq
 import pytest
 from OCP.OSD import OSD_ThreadPool
 
 from cad_to_dagmc import CadToDagmc
-from cad_to_dagmc.core import imprint_assembly, resolve_imprint, thread_limit
+from cad_to_dagmc.core import (
+    imprint_assembly,
+    imprint_thread_limit,
+    resolve_imprint,
+    thread_limit,
+)
 
 
 def _pool_threads():
@@ -74,6 +84,66 @@ class TestThreadLimit:
         assert _pool_threads() == before
 
 
+class TestImprintThreadLimit:
+    """The limit has to land on the imprint and on nothing either side of it."""
+
+    def test_only_the_imprint_call_is_limited(self):
+        before = _pool_threads()
+        inside_the_imprint = []
+
+        real_imprint = cq.occ_impl.assembly.imprint
+
+        @functools.wraps(real_imprint)
+        def spy(*args, **kwargs):
+            inside_the_imprint.append(_pool_threads())
+            return real_imprint(*args, **kwargs)
+
+        cq.occ_impl.assembly.imprint = spy
+        try:
+            with imprint_thread_limit(2):
+                # Stands in for the meshing a backend does before it imprints.
+                assert _pool_threads() == before
+                cq.occ_impl.assembly.imprint(_two_touching_boxes())
+                # ...and for the meshing it does afterwards.
+                assert _pool_threads() == before
+        finally:
+            cq.occ_impl.assembly.imprint = real_imprint
+
+        assert inside_the_imprint == [2]
+        assert _pool_threads() == before
+
+    def test_the_original_imprint_is_put_back(self):
+        real_imprint = cq.occ_impl.assembly.imprint
+        with imprint_thread_limit(2):
+            assert cq.occ_impl.assembly.imprint is not real_imprint
+        assert cq.occ_impl.assembly.imprint is real_imprint
+
+    def test_the_original_imprint_is_put_back_after_an_exception(self):
+        real_imprint = cq.occ_impl.assembly.imprint
+        before = _pool_threads()
+        with pytest.raises(RuntimeError):
+            with imprint_thread_limit(2):
+                raise RuntimeError("meshing failed")
+        assert cq.occ_impl.assembly.imprint is real_imprint
+        assert _pool_threads() == before
+
+    def test_the_glue_argument_stays_visible(self):
+        """imprint_assembly and cad-to-dagmc-mesher both inspect the signature
+        to decide whether to pass glue="partial", so the wrapper must not hide
+        it."""
+        import inspect
+
+        real_params = inspect.signature(cq.occ_impl.assembly.imprint).parameters
+        with imprint_thread_limit(2):
+            wrapped_params = inspect.signature(cq.occ_impl.assembly.imprint).parameters
+        assert list(wrapped_params) == list(real_params)
+
+    def test_none_leaves_the_imprint_alone(self):
+        real_imprint = cq.occ_impl.assembly.imprint
+        with imprint_thread_limit(None):
+            assert cq.occ_impl.assembly.imprint is real_imprint
+
+
 class TestImprintAssembly:
     def test_threads_are_restored_after_imprinting(self):
         before = _pool_threads()
@@ -130,6 +200,194 @@ def test_export_unstructured_mesh_file_with_thread_limited_imprint(tmp_path):
 
     assert vtk_filename.is_file()
     assert _pool_threads() == before
+
+
+@pytest.fixture
+def imprint_spy(monkeypatch):
+    """Record the size of the OCC thread pool each time an imprint runs.
+
+    Restoring the pool afterwards is not enough on its own, the limit also has
+    to be in place while the imprint is running. The cadquery plugin and
+    cad-to-dagmc-mesher call cq.occ_impl.assembly.imprint themselves, so
+    patching it here catches the imprint whichever backend triggers it.
+    """
+    real_imprint = cq.occ_impl.assembly.imprint
+    pool_sizes = []
+
+    # functools.wraps keeps the signature visible to the inspect.signature
+    # check in imprint_assembly that looks for the glue argument.
+    @functools.wraps(real_imprint)
+    def spy(*args, **kwargs):
+        pool_sizes.append(_pool_threads())
+        return real_imprint(*args, **kwargs)
+
+    monkeypatch.setattr(cq.occ_impl.assembly, "imprint", spy)
+    return pool_sizes
+
+
+def _dagmc_h5m(backend, **kwargs):
+    def export(model, tmp_path, imprint):
+        model.export_dagmc_h5m_file(
+            filename=str(tmp_path / "dagmc.h5m"),
+            meshing_backend=backend,
+            imprint=imprint,
+            **kwargs,
+        )
+
+    return export
+
+
+def _gmsh_mesh(model, tmp_path, imprint):
+    model.export_gmsh_mesh_file(filename=str(tmp_path / "mesh.msh"), imprint=imprint)
+
+
+def _unstructured(backend, **kwargs):
+    def export(model, tmp_path, imprint):
+        model.export_unstructured_mesh_file(
+            filename=str(tmp_path / "umesh.vtk"),
+            meshing_backend=backend,
+            imprint=imprint,
+            **kwargs,
+        )
+
+    return export
+
+
+# Every route through the library that ends in an imprint, with the backends
+# that need cad-to-dagmc-mesher flagged so they skip when it is not installed.
+IMPRINT_PATHS = {
+    "h5m_gmsh": (_dagmc_h5m("gmsh"), False),
+    "h5m_cadquery": (_dagmc_h5m("cadquery"), False),
+    "h5m_mesher": (_dagmc_h5m("cad-to-dagmc-mesher"), True),
+    "h5m_gmsh_with_umesh": (
+        _dagmc_h5m("gmsh", unstructured_volumes=["mat1"], umesh_filename="umesh.vtk"),
+        False,
+    ),
+    "h5m_mesher_with_tets": (
+        _dagmc_h5m(
+            "cad-to-dagmc-mesher",
+            tet_volumes=["mat1"],
+            target_edge_length=3.0,
+        ),
+        True,
+    ),
+    "gmsh_mesh_file": (_gmsh_mesh, False),
+    "unstructured_gmsh": (_unstructured("gmsh"), False),
+    "unstructured_mesher": (_unstructured("cad-to-dagmc-mesher", target_edge_length=3.0), True),
+}
+
+
+@pytest.mark.parametrize("path", IMPRINT_PATHS.keys())
+def test_every_imprint_path_imprints_on_the_requested_threads(
+    tmp_path, monkeypatch, imprint_spy, path
+):
+    """imprint=<int> has to reach the imprint on every export path.
+
+    The three export methods reach an imprint by several routes: some imprint
+    directly, others hand the assembly to a backend that imprints inside its
+    own meshing call. All of them must run the imprint on the requested number
+    of threads and put the previous count back afterwards.
+    """
+    export, needs_mesher = IMPRINT_PATHS[path]
+    if needs_mesher:
+        pytest.importorskip("cad_to_dagmc_mesher")
+
+    requested = 3
+    before = _pool_threads()
+    # umesh_filename is relative in one of the cases above, so write from
+    # tmp_path rather than littering the repo.
+    monkeypatch.chdir(tmp_path)
+
+    export(_model(), tmp_path, requested)
+
+    assert imprint_spy == [requested], (
+        f"{path} imprinted with pool sizes {imprint_spy}, expected one imprint "
+        f"on {requested} threads"
+    )
+    assert _pool_threads() == before
+
+
+@pytest.mark.parametrize("path", IMPRINT_PATHS.keys())
+def test_every_imprint_path_leaves_the_pool_alone_for_bools(
+    tmp_path, monkeypatch, imprint_spy, path
+):
+    """imprint=True must not touch the pool, it imprints on whatever is set."""
+    export, needs_mesher = IMPRINT_PATHS[path]
+    if needs_mesher:
+        pytest.importorskip("cad_to_dagmc_mesher")
+
+    before = _pool_threads()
+    monkeypatch.chdir(tmp_path)
+
+    export(_model(), tmp_path, True)
+
+    assert imprint_spy == [before]
+    assert _pool_threads() == before
+
+
+def test_cadquery_backend_tessellates_on_all_threads(tmp_path, monkeypatch, imprint_spy):
+    """The plugin imprints inside toMesh, but only the imprint is limited.
+
+    BRepMesh_IncrementalMesh is the tessellation and it runs on the same OCC
+    pool as the imprint, so it is what would be slowed down if the limit
+    covered the whole toMesh call instead of just the imprint.
+    """
+    plugin = pytest.importorskip("cadquery_direct_mesh_plugin.plugin")
+
+    before = _pool_threads()
+    tessellation_pool_sizes = []
+    real_tessellate = plugin.BRepMesh_IncrementalMesh
+
+    def spy(*args, **kwargs):
+        tessellation_pool_sizes.append(_pool_threads())
+        return real_tessellate(*args, **kwargs)
+
+    monkeypatch.setattr(plugin, "BRepMesh_IncrementalMesh", spy)
+
+    _model().export_dagmc_h5m_file(
+        filename=str(tmp_path / "dagmc.h5m"),
+        meshing_backend="cadquery",
+        imprint=1,
+    )
+
+    assert imprint_spy == [1], "the imprint should have been limited"
+    assert tessellation_pool_sizes, "the plugin did not tessellate anything"
+    assert set(tessellation_pool_sizes) == {before}, (
+        "tessellation ran on a limited pool, the imprint limit is leaking into "
+        "the meshing"
+    )
+
+
+def test_mesher_backend_meshes_on_all_threads(tmp_path, monkeypatch, imprint_spy):
+    """Same again for cad-to-dagmc-mesher, which also imprints part way
+    through its own meshing call. Probing just after its imprint returns shows
+    whether the pool is back up for the meshing that follows."""
+    mesher_assembly = pytest.importorskip("cad_to_dagmc_mesher.cad._assembly")
+    if not hasattr(mesher_assembly, "_imprint_assembly"):
+        pytest.skip("cad-to-dagmc-mesher no longer has _imprint_assembly to probe")
+
+    before = _pool_threads()
+    pool_after_the_imprint = []
+    real_imprint_assembly = mesher_assembly._imprint_assembly
+
+    def spy(*args, **kwargs):
+        result = real_imprint_assembly(*args, **kwargs)
+        pool_after_the_imprint.append(_pool_threads())
+        return result
+
+    monkeypatch.setattr(mesher_assembly, "_imprint_assembly", spy)
+
+    _model().export_dagmc_h5m_file(
+        filename=str(tmp_path / "dagmc.h5m"),
+        meshing_backend="cad-to-dagmc-mesher",
+        imprint=1,
+    )
+
+    assert imprint_spy == [1], "the imprint should have been limited"
+    assert pool_after_the_imprint == [before], (
+        "the pool was still limited once the imprint had finished, the limit "
+        "is leaking into the meshing"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow up to #212, which added `imprint=<int>`.

## The problem

`imprint=<int>` shrinks the OpenCASCADE thread pool for the imprint, because imprinting runs in parallel and its peak RAM scales with the thread count. Which part of the export that limit covered depended on the backend:

| Backend | Limit covered |
|---|---|
| `gmsh` | the imprint only, cad_to_dagmc imprints before handing the geometry over |
| `cadquery` | the whole `toMesh` call, the plugin imprints inside it |
| `cad-to-dagmc-mesher` | the whole `mesh_assembly` call, the mesher imprints inside it |

For the latter two the meshing ran on the reduced thread count as well. That matters most for `meshing_backend="cadquery"`, where `BRepMesh_IncrementalMesh` tessellates on the same pool, so `imprint=1` quietly made the tessellation single threaded. Measured on a tessellation heavy model with 32 cores available:

```
imprint=True  (no limit)                    2.54s
imprint=1     old scope, whole toMesh       3.18s  (1.25x)
imprint=1     new scope, imprint only       2.50s  (0.98x)
```

## The change

The argument exists to keep the imprint inside memory, so the limit should not be paying for that in meshing time. Both backends reach the imprint through `cq.occ_impl.assembly.imprint` and look it up when they call it, so there is a seam even though there is no outer one. `imprint_thread_limit` swaps in a wrapper that shrinks the pool around the real imprint and puts the original function back on the way out, including when meshing raises part way through.

`functools.wraps` on the wrapper is load bearing: `imprint_assembly` and cad-to-dagmc-mesher both check the signature for the `glue` argument before calling it.

The gmsh path is unchanged, it already wrapped only the imprint.

## Tests

`tests/test_imprint_threads.py` now covers all eight routes through the library that end in an imprint, asserting the imprint runs on the requested threads and the pool is restored. Two new tests assert the other half of the contract, that the tessellation and the meshing either side of the imprint are not limited, by probing the pool size from inside `BRepMesh_IncrementalMesh` and from just after the mesher's own imprint returns.

Both new tests fail if the call sites are reverted to the old whole call scope. The pre-existing tests did not, they only checked the pool was restored once the export was over.

227 passed, 2 skipped locally, plus the docs codeblocks.