### PR TITLE
Make tolerance consistent across meshing backends

### DIFF
--- a/docs/meshing/cad_to_dagmc_mesher_backend.md
+++ b/docs/meshing/cad_to_dagmc_mesher_backend.md
@@ -65,15 +65,32 @@ dagmc_filename, umesh_filename = model.export_dagmc_h5m_file(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tolerance` | float | 0.01 | Linear deflection tolerance for the surface mesh |
+| `tolerance` | float | 0.01 | Linear deflection tolerance for the surface mesh, in the units of the scaled geometry |
 | `angular_tolerance` | float | 0.2 | Angular deflection tolerance for the surface mesh |
-| `target_edge_length` | float | None | Target tetrahedron edge length for the volume mesh |
+| `target_edge_length` | float | None | Target tetrahedron edge length for the volume mesh, in the units of the scaled geometry |
 | `tet_volumes` | Iterable[str] | None | Material tag names of the volumes to fill with tetrahedra |
 
 **Tolerance explanation:**
 - `tolerance` controls how far the surface mesh can deviate from the true surface (linear distance)
 - `angular_tolerance` controls the maximum angle between adjacent facet normals
 - `target_edge_length` controls the size of the tetrahedra in the volume mesh
+
+:::{important}
+`tolerance` and `target_edge_length` are lengths in the units of the **scaled**
+geometry, because this backend applies `scale_factor` to the geometry before
+meshing it.
+
+So if you pass `scale_factor=100` to convert a model from metres to centimetres,
+`tolerance` is in centimetres. The `0.01` default then means a 0.1 mm deflection,
+which on a large model can produce an enormous number of facets and exhaust
+memory. Scale the tolerance along with the geometry: for a metre-scale model
+exported with `scale_factor=100`, something like `tolerance=0.5` (5 mm) is a more
+reasonable starting point.
+
+The gmsh and cadquery backends take their linear mesh sizes in scaled-geometry
+units too, so a given number means the same deflection whichever backend you use.
+`angular_tolerance` is an angle and is unaffected by scaling.
+:::
 
 ## Backend Auto-Selection
 

--- a/docs/meshing/cadquery_backend.md
+++ b/docs/meshing/cadquery_backend.md
@@ -61,6 +61,20 @@ When using `meshing_backend="cadquery"`, the following parameters are **ignored*
 - `mesh_algorithm`
 :::
 
+:::{note}
+`tolerance` is in the units of the **scaled** geometry, the same as the gmsh and
+cad-to-dagmc-mesher backends, so with `scale_factor=100` a `tolerance` of 0.5 is a
+5 mm deflection on the output mesh.
+
+This backend tessellates the unscaled geometry and scales the resulting vertices
+afterwards, so internally the tolerance is divided by `scale_factor` before being
+handed to the tessellator. Earlier versions did not do this, which meant the same
+`tolerance` value gave a `scale_factor` times coarser mesh here than with the other
+backends. If you relied on the old behaviour, multiply your tolerance by
+`scale_factor`; a warning is raised when `scale_factor` is not 1.0 to flag the
+change.
+:::
+
 ## When to Use CadQuery Backend
 
 **Good for:**

--- a/docs/outputs/dagmc_h5m.md
+++ b/docs/outputs/dagmc_h5m.md
@@ -94,7 +94,7 @@ model.export_dagmc_h5m_file(
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `filename` | str | "dagmc.h5m" | Output file path |
-| `scale_factor` | float | 1.0 | Geometry scale factor |
+| `scale_factor` | float | 1.0 | Geometry scale factor. See the note below on how it affects the units of the linear mesh sizing parameters |
 | `imprint` | bool or int | True | Imprint shared surfaces. An int limits the imprint to that many threads |
 | `implicit_complement_material_tag` | str | None | Void space material tag |
 
@@ -125,7 +125,7 @@ These parameters only apply when using `meshing_backend="cadquery"`:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tolerance` | float | 0.1 | Linear tolerance for tessellation |
+| `tolerance` | float | 0.1 | Linear tolerance for tessellation, in scaled-geometry units |
 | `angular_tolerance` | float | 0.1 | Angular tolerance for tessellation |
 
 **cad-to-dagmc-mesher Backend Parameters:**
@@ -134,11 +134,41 @@ These parameters only apply when using `meshing_backend="cad-to-dagmc-mesher"`:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `tolerance` | float | 0.01 | Linear tolerance for the surface mesh |
+| `tolerance` | float | 0.01 | Linear tolerance for the surface mesh, in scaled-geometry units |
 | `angular_tolerance` | float | 0.2 | Angular tolerance for the surface mesh |
 | `tet_volumes` | Iterable[str] | None | Material tag names of the volumes to fill with tetrahedra |
-| `target_edge_length` | float | None | Target tetrahedron edge length |
+| `target_edge_length` | float | None | Target tetrahedron edge length, in scaled-geometry units |
 | `umesh_filename` | str | "umesh.vtk" | Output filename for unstructured volume mesh |
+
+:::{important}
+**`scale_factor` and the units of linear mesh sizes.** All the linear mesh sizing
+parameters are in the units of the **scaled** geometry, so the same number means
+the same deflection on the output mesh whichever backend you use:
+
+| Backend | Linear sizing parameters |
+|---------|--------------------------|
+| `gmsh` | `min_mesh_size`, `max_mesh_size`, `set_size` |
+| `cad-to-dagmc-mesher` | `tolerance`, `target_edge_length` |
+| `cadquery` | `tolerance` |
+
+A consequence is that the defaults get finer as `scale_factor` grows. This matters
+most for the cad-to-dagmc-mesher `tolerance` default of `0.01`: with
+`scale_factor=100` (metres to centimetres) that is a 0.1 mm deflection, which on a
+large model can generate a huge number of facets and exhaust memory. Scale the
+tolerance with the geometry, for example `tolerance=0.5` (5 mm) for a metre-scale
+model exported with `scale_factor=100`.
+
+`angular_tolerance` is an angle and is unaffected by `scale_factor`.
+:::
+
+:::{note}
+Before this behaviour was made consistent, the `cadquery` backend interpreted
+`tolerance` in the units of the *unscaled* geometry, because it tessellates first
+and scales the resulting vertices afterwards. If you used that backend with a
+`scale_factor` other than 1.0, the same `tolerance` value now produces a mesh
+`scale_factor` times finer than it used to; multiply your old tolerance by
+`scale_factor` to get the previous mesh density. A warning is raised to flag this.
+:::
 
 `tet_volumes` and `target_edge_length` must be given together to write a volume mesh.
 

--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -1803,9 +1803,15 @@ class CadToDagmc:
                 volumes to fill with tetrahedra when using the
                 cad-to-dagmc-mesher backend. Defaults to all volumes.
             tolerance: linear deflection tolerance for the surface mesh, used by
-                the cad-to-dagmc-mesher backend.
+                the cad-to-dagmc-mesher backend. This is in the units of the
+                SCALED geometry, since scale_factor is applied before meshing,
+                so scale it alongside scale_factor. With scale_factor=100 the
+                0.01 default is a 0.1 mm deflection, which on a large model can
+                produce a very fine mesh and exhaust memory. The same applies to
+                min_mesh_size/max_mesh_size/set_size for the gmsh backend.
             angular_tolerance: angular deflection tolerance for the surface mesh,
-                used by the cad-to-dagmc-mesher backend.
+                used by the cad-to-dagmc-mesher backend. An angle, so unaffected
+                by scale_factor.
 
 
         Returns:
@@ -2101,7 +2107,19 @@ class CadToDagmc:
             filename: the filename to use for the saved DAGMC file.
             implicit_complement_material_tag: the name of the material tag to use
                 for the implicit complement (void space).
-            scale_factor: a scaling factor to apply to the geometry.
+            scale_factor: a scaling factor to apply to the geometry. All the
+                linear mesh sizing arguments (min_mesh_size, max_mesh_size and
+                set_size for gmsh, tolerance and target_edge_length for
+                cad-to-dagmc-mesher, tolerance for cadquery) are in the units of
+                the SCALED geometry, so the same number means the same thing on
+                the output mesh whichever backend is used. For example with
+                scale_factor=100 (m to cm) a tolerance of 0.5 is a 5 mm
+                deflection. Note this means the defaults get finer as
+                scale_factor grows: the cad-to-dagmc-mesher tolerance default of
+                0.01 is a 0.1 mm deflection at scale_factor=100, which on a large
+                model can produce a very fine mesh and exhaust memory, so scale
+                the tolerance along with the geometry. angular_tolerance is an
+                angle and so is unaffected by scaling.
             imprint: whether to imprint the geometry or not. A positive int can be
                 passed instead of True to imprint with that many threads, for example
                 imprint=1 imprints on a single thread. Imprinting runs in parallel and
@@ -2140,11 +2158,16 @@ class CadToDagmc:
                   available cores (default), 1 uses a single thread.
 
                 For CadQuery backend:
-                - tolerance (float): meshing tolerance (default: 0.1)
+                - tolerance (float): meshing tolerance (default: 0.1), in the
+                  units of the scaled geometry (see scale_factor above)
                 - angular_tolerance (float): angular tolerance (default: 0.1)
 
                 For cad-to-dagmc-mesher backend:
-                - tolerance (float): surface meshing tolerance (default: 0.01)
+                - tolerance (float): surface meshing tolerance (default: 0.01),
+                  in the units of the scaled geometry (see scale_factor above).
+                  With scale_factor=100 the 0.01 default is a 0.1 mm deflection,
+                  which on a large model can produce a very fine mesh and
+                  exhaust memory; scale the value with scale_factor.
                 - angular_tolerance (float): surface angular tolerance (default: 0.2)
                 - tet_volumes (Iterable[str]): material tag names of the volumes to
                   fill with tetrahedra for an unstructured volume mesh.
@@ -2330,6 +2353,23 @@ class CadToDagmc:
             tolerance = kwargs.get("tolerance", 0.1)
             angular_tolerance = kwargs.get("angular_tolerance", 0.1)
 
+            if scale_factor != 1.0:
+                # Transitional warning: tolerance used to be in unscaled units
+                # for this backend only. Remove in a future release once the
+                # consistent behaviour has been out for a while.
+                warnings.warn(
+                    f"tolerance ({tolerance}) is in the units of the scaled "
+                    f"geometry, so with scale_factor={scale_factor} it is a "
+                    f"deflection of {tolerance} in the output mesh's units. "
+                    "This matches the gmsh and cad-to-dagmc-mesher backends. "
+                    "Previous versions of cad_to_dagmc interpreted tolerance in "
+                    "the units of the unscaled geometry for the cadquery "
+                    "backend only, so this produces a mesh "
+                    f"{scale_factor}x finer than before for the same tolerance; "
+                    f"pass tolerance={tolerance * scale_factor} to reproduce the "
+                    "old mesh density."
+                )
+
             # Check for invalid parameters
             unstructured_volumes = kwargs.get("unstructured_volumes")
             if unstructured_volumes is not None or kwargs.get("tet_volumes") is not None:
@@ -2411,13 +2451,22 @@ class CadToDagmc:
             # Use the CadQuery direct mesh plugin
             if meshing_backend == "cadquery":
                 import cadquery_direct_mesh_plugin
+                # tolerance is documented as being in the units of the scaled
+                # geometry, matching the gmsh and cad-to-dagmc-mesher backends
+                # (both of which scale the geometry before meshing it). This
+                # backend is the odd one out: the plugin tessellates the
+                # unscaled solids and multiplies the resulting vertices by
+                # scale_factor afterwards, so the tolerance it is given is in
+                # unscaled units. Convert so the same number means the same
+                # deflection on the output mesh whichever backend is used.
+                cq_tolerance = tolerance / scale_factor
                 # Mesh the assembly using CadQuery's direct-mesh plugin. The
                 # plugin imprints internally, so the limit is put on the
                 # imprint itself and the tessellation keeps all its threads.
                 with imprint_thread_limit(imprint_threads):
                     cq_mesh = assembly.toMesh(
                         imprint=imprint,
-                        tolerance=tolerance,
+                        tolerance=cq_tolerance,
                         angular_tolerance=angular_tolerance,
                         scale_factor=scale_factor,
                     )

--- a/tests/test_tolerance_scale_factor.py
+++ b/tests/test_tolerance_scale_factor.py
@@ -1,0 +1,86 @@
+import cadquery as cq
+import pytest
+
+from cad_to_dagmc import CadToDagmc
+
+
+class _StopAfterCapture(Exception):
+    """Raised by the toMesh stub once the arguments have been recorded."""
+
+
+def _capture_cadquery_tolerance(monkeypatch, scale_factor, **kwargs):
+    """Return the tolerance that reaches CadQuery's toMesh.
+
+    The cadquery backend tessellates the unscaled geometry and scales the
+    resulting vertices, so cad_to_dagmc has to convert the caller's
+    scaled-geometry tolerance before handing it over. Capture that value
+    rather than meshing, which keeps the test fast and exact.
+    """
+    import cadquery_direct_mesh_plugin  # noqa: F401  registers Assembly.toMesh
+
+    captured = {}
+
+    def fake_to_mesh(self, **to_mesh_kwargs):
+        captured.update(to_mesh_kwargs)
+        raise _StopAfterCapture
+
+    monkeypatch.setattr(cq.Assembly, "toMesh", fake_to_mesh)
+
+    model = CadToDagmc()
+    model.add_cadquery_object(cq.Workplane().sphere(1), material_tags=["mat1"])
+
+    with pytest.raises(_StopAfterCapture):
+        model.export_dagmc_h5m_file(
+            filename="unused.h5m",
+            meshing_backend="cadquery",
+            scale_factor=scale_factor,
+            **kwargs,
+        )
+    return captured
+
+
+@pytest.mark.parametrize("scale_factor", [2.0, 100.0])
+def test_cadquery_tolerance_is_in_scaled_units(monkeypatch, scale_factor):
+    """tolerance is divided by scale_factor for the cadquery backend.
+
+    Without this the same tolerance means a scale_factor times coarser mesh on
+    the cadquery backend than on gmsh/cad-to-dagmc-mesher, which scale the
+    geometry before meshing it.
+    """
+    with pytest.warns(UserWarning, match="units of the scaled geometry"):
+        captured = _capture_cadquery_tolerance(
+            monkeypatch, scale_factor, tolerance=0.5
+        )
+
+    assert captured["tolerance"] == pytest.approx(0.5 / scale_factor)
+    # the geometry itself is still scaled by the plugin, unchanged
+    assert captured["scale_factor"] == scale_factor
+
+
+def test_cadquery_tolerance_unchanged_without_scaling(monkeypatch):
+    """scale_factor=1.0 passes the tolerance straight through and does not warn."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        captured = _capture_cadquery_tolerance(monkeypatch, 1.0, tolerance=0.5)
+
+    assert captured["tolerance"] == pytest.approx(0.5)
+
+
+def test_cadquery_default_tolerance_is_scaled(monkeypatch):
+    """The 0.1 default is in scaled units too, so it is converted as well."""
+    with pytest.warns(UserWarning, match="units of the scaled geometry"):
+        captured = _capture_cadquery_tolerance(monkeypatch, 100.0)
+
+    assert captured["tolerance"] == pytest.approx(0.1 / 100.0)
+
+
+def test_angular_tolerance_is_not_scaled(monkeypatch):
+    """angular_tolerance is an angle, so scale_factor must not touch it."""
+    with pytest.warns(UserWarning):
+        captured = _capture_cadquery_tolerance(
+            monkeypatch, 100.0, tolerance=0.5, angular_tolerance=0.3
+        )
+
+    assert captured["angular_tolerance"] == pytest.approx(0.3)


### PR DESCRIPTION
## Problem

`scale_factor` is applied at different points by different backends, so the same `tolerance` number meant different things depending on which backend you used:

| Backend | Where `scale_factor` is applied | `tolerance` was in |
|---|---|---|
| `gmsh` | `gmsh.model.occ.dilate` in `get_volumes`, **before** `set_sizes_for_mesh`/`mesh.generate` | scaled units |
| `cad-to-dagmc-mesher` | `Shape.scale()` per part in `_build_assembly`, **before** meshing | scaled units |
| `cadquery` | vertex coords `× scale_factor` in the plugin, **after** `BRepMesh_IncrementalMesh` | **original units** |

So with `scale_factor=100`, `tolerance=0.5` was a 5 mm deflection under cad-to-dagmc-mesher but a 500 mm deflection under cadquery — a 100× difference from the same argument, with nothing in the docs to say so. cadquery was the odd one out, two backends to one.

This bit me on a real model: the cad-to-dagmc-mesher `tolerance` default of `0.01` is a 0.1 mm deflection at `scale_factor=100`, which exhausted 24 GB of RAM on a single sub-assembly before I worked out that the units followed the scale factor.

## Changes

**Behaviour** — the cadquery backend now divides `tolerance` by `scale_factor` before handing it to the tessellator, so all three backends take linear mesh sizes in scaled-geometry units and the same number means the same deflection on the output mesh. The cheap conversion is possible precisely because the plugin scales vertices after tessellating; no geometry copy is needed.

**Warning** — when `scale_factor != 1.0` on the cadquery backend, a transitional `UserWarning` states the units and gives the multiplier to reproduce the old density. Worth removing after a release or two.

**Docs** — `scale_factor` and the tolerance entries now state the units in the `export_dagmc_h5m_file` and `export_unstructured_mesh_file` docstrings, with admonitions on the cad-to-dagmc-mesher, cadquery and dagmc_h5m pages. Includes the memory trap around the `0.01` default at large scale factors.

**Tests** — `tests/test_tolerance_scale_factor.py` stubs `Assembly.toMesh` to capture the tolerance actually passed through, so it is exact and fast rather than measuring facet counts. Covers the conversion at two scale factors, the default, `scale_factor=1.0` passing through unchanged with no warning, and `angular_tolerance` being left alone.

## Compatibility

This is a **behaviour change** for anyone using `meshing_backend="cadquery"` together with `scale_factor != 1.0`: the same `tolerance` now yields a mesh `scale_factor` times finer. Multiply the old tolerance by `scale_factor` to restore the previous density. gmsh and cad-to-dagmc-mesher are unaffected. Worth a minor version bump and a changelog line.

## Verification

New tests pass (5), and they fail (3) when the conversion is reverted, so they genuinely pin the behaviour.

`tests/test_kwarg_args.py` has 8 pre-existing failures in my environment — identical with and without this change, from `ValueError: Null TopoDS_Shape object` in cadquery 2.9.0.dev0, i.e. an environment issue rather than a regression here. The new tests avoid that path by stubbing the tessellation. Worth confirming against CI.
