### PR TITLE
Require cad-to-dagmc-mesher 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gmsh",
     "h5py",
     "cadquery_direct_mesh_plugin>=0.2.0",
-    "cad-to-dagmc-mesher>=0.1.10"
+    "cad-to-dagmc-mesher>=0.1.11"
 # TODO if moab become available on pypi include moab here and remove from CI
 # python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
 ]


### PR DESCRIPTION
## Why

The pin is `>=0.1.10`, but the advice this package prints does not work on 0.1.10.

When the mesher's surface mesh is too coarse, cad_to_dagmc relays its warning verbatim:

```
WARNING: solid 2: mesh looks too coarse — 112 edge(s) fold to 180° (facets doubling
back). DAGMC often loses particles here. Confirm with
transport_check.check_transport_readiness(h5m); if it loses particles, remesh at a
finer tolerance (smaller value).
  (run cad_to_dagmc_mesher.transport_check.check_transport_readiness(h5m) to confirm
   in DAGMC transport)
```

On mesher 0.1.10 following that instruction raises immediately:

```
AttributeError: module 'dagmc_h5m_file_inspector' has no attribute
'get_bounding_box_from_h5m'
```

0.1.10 called an inspector function that dagmc_h5m_file_inspector 0.7.0 renamed, and 0.1.11 fixes it. So a user on 0.1.10 gets told to run a check that cannot run. Raising the floor makes the advice we print actually actionable.

## Verification against 0.1.11

Clean `cad-to-dagmc-mesher==0.1.11` install, `cad_to_dagmc` at main (0.13.3.dev2):

- `tests/test_mesher_mesh_quality.py` — **5 passed**
- End to end through `export_dagmc_h5m_file(meshing_backend="cad-to-dagmc-mesher")` on a shape that trips the coarse-mesh warning: exported fine, and then following the printed advice worked — `check_transport_readiness` returned `ready=True, lost=0/50000`.

`tests/test_kwarg_args.py` has 8 failures in my environment, all `ValueError: Null TopoDS_Shape object` from the **cadquery** backend on cadquery 2.9.0.dev0. They are unrelated to the mesher version — the same 8 fail with 0.1.10 installed — but worth a look separately, and worth confirming against CI's cadquery.

## Note

Nothing in cad_to_dagmc's own code path needs 0.1.11: it imports only `mesh_assembly`, not `transport_check`. This is about the guidance we surface to users being usable. If you would rather not raise a floor for a warning message, the alternative is to stop relaying the `check_transport_readiness` suggestion — but the suggestion is genuinely the right next step for a user seeing that warning, so requiring a version where it works seems better.
