### PR TITLE
Require cad-to-dagmc-mesher 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "gmsh",
     "h5py",
     "cadquery_direct_mesh_plugin>=0.2.0",
-    "cad-to-dagmc-mesher>=0.1.11"
+    "cad-to-dagmc-mesher>=0.2.0"
 # TODO if moab become available on pypi include moab here and remove from CI
 # python -m pip install --extra-index-url https://shimwell.github.io/wheels moab
 ]


### PR DESCRIPTION
## Why

The pin is `>=0.1.11`, which permits an install where the headline behaviour of this package silently does not happen.

`cad_to_dagmc` now drives the mesher through `solid_config` and relies on its automatic refinement: the mesher re-meshes any solid whose facets fold back, because those folds are where DAGMC loses particles. **`auto_refine` does not exist in 0.1.11.** It arrived in 0.2.0.

So a user who resolves the mesher to 0.1.11 gets:

| | 0.1.11 | 0.2.0 |
|---|--------|-------|
| per-solid meshing via `solid_config` | yes | yes |
| overlapping-CAD rejection | yes | yes |
| **automatic refinement of folding solids** | **no** | yes |
| imprint thread control (`imprint=1`) | no | yes |

Nothing errors — I verified `cad_to_dagmc` main against 0.1.11 and 67 tests pass, because `OverlappingSolidsError` and `SolidConfig.target_edge_length` both exist there. The problem is quieter than a failure: refinement simply never happens, with no warning, and the documentation describes behaviour the user does not have. On the model this was developed against, that is the difference between 18,172 lost particles per million and zero.

0.2.0 is published, so there is no reason to keep the older floor.

## Verification

- `cad_to_dagmc` main against the real PyPI 0.2.0 wheel: **253 passed**, 12 skipped, 0 failed, plus 41 docs snippets passing.
- Against the current 0.1.11 floor: 67 passed — hence "silently degraded" rather than "broken", which is the argument for raising it.
- With this change: 48 passed on the mesher-backend, overlapping-solids and kwargs suites.

## Caveat

This raises the floor for everyone, including anyone pinned to an older mesher for an unrelated reason. Given 0.2.0 is a superset in behaviour and the two packages are released together, that seems right — but it is a dependency tightening rather than a bug fix, so it belongs in the release notes.
