### PR TITLE
Weld shared vertices when combining the per solid tet meshes

### DIFF
--- a/src/cad_to_dagmc/core.py
+++ b/src/cad_to_dagmc/core.py
@@ -105,14 +105,27 @@ def combine_tet_meshes(tet_data):
     arrays are concatenated and each solid's tetrahedra are offset by the
     running vertex count so they index into the combined vertex array.
 
+    Solids that were imprinted against each other are meshed from the same
+    surface mesh on the face they share, so each of them carries its own copy
+    of the vertices on that face. Concatenating the arrays leaves those copies
+    as separate points and the result is a mesh that looks like one body but is
+    really several that only touch, which matters to anything solving on it. A
+    finite element solve on such a mesh treats the shared face as an exterior
+    boundary on both sides and nothing crosses it.
+
+    The duplicate coordinates are bit for bit identical, so they are merged
+    here on an exact match. Nothing is merged on proximity, which means solids
+    that do not touch keep their own vertices and stay as separate bodies, as
+    they should.
+
     Args:
         tet_data: Mapping of solid_id -> dict with "vertices" and
             "tetrahedra" entries, as returned by mesh_assembly.
 
     Returns:
         (vertices, tetrahedra): a single (N, 3) float array of vertex
-        coordinates and a single (M, 4) int array of zero-based tetrahedron
-        vertex indices.
+        coordinates with no exact duplicates, and a single (M, 4) int array of
+        zero-based tetrahedron vertex indices.
     """
     all_vertices = []
     all_tetrahedra = []
@@ -127,7 +140,20 @@ def combine_tet_meshes(tet_data):
     if not all_vertices:
         return np.empty((0, 3), dtype=float), np.empty((0, 4), dtype=np.int64)
 
-    return np.vstack(all_vertices), np.vstack(all_tetrahedra)
+    vertices = np.vstack(all_vertices)
+    tetrahedra = np.vstack(all_tetrahedra)
+
+    # first_index maps each kept vertex back to where it first appeared, so the
+    # vertices stay in the order the solids were meshed in rather than being
+    # sorted, and remap turns the old indices into the new ones
+    _, first_index, inverse = np.unique(
+        vertices, axis=0, return_index=True, return_inverse=True
+    )
+    keep = np.sort(first_index)
+    remap = np.empty(len(keep), dtype=np.int64)
+    remap[np.argsort(first_index)] = np.arange(len(keep))
+
+    return vertices[keep], remap[inverse.reshape(-1)][tetrahedra]
 
 
 def resolve_imprint(imprint: bool | int) -> tuple[bool, int | None]:

--- a/tests/test_write_vtk.py
+++ b/tests/test_write_vtk.py
@@ -136,8 +136,14 @@ def test_write_vtk_accepts_numpy_arrays():
         os.unlink(filename)
 
 
-def test_combine_tet_meshes_offsets_indices():
-    """Per-solid tetrahedra must be offset by the running vertex count."""
+def _tet_coordinates(vertices, tetrahedra):
+    """Every tet as a sorted tuple of coordinates, so meshes compare by geometry."""
+    return sorted(tuple(sorted(map(tuple, vertices[tet]))) for tet in tetrahedra)
+
+
+def test_combine_tet_meshes_welds_shared_vertices():
+    """Vertices two solids have in common are merged and the indices remapped."""
+    # the two boxes meet on the x=0 face, so 4 of their 8 corners are in common
     verts_a, tets_a = _box_to_tets(-2, -2, -2, 2, 4, 4)
     verts_b, tets_b = _box_to_tets(0, -2, -2, 2, 4, 4)
 
@@ -149,20 +155,65 @@ def test_combine_tet_meshes_offsets_indices():
 
     vertices, tetrahedra = combine_tet_meshes(tet_data)
 
-    # Vertices are concatenated.
-    assert vertices.shape == (16, 3)
+    # 16 vertices in, the 4 on the shared face kept once, so 12 out
+    assert vertices.shape == (12, 3)
     assert tetrahedra.shape == (12, 4)
+    assert len(np.unique(vertices, axis=0)) == 12
+
+    # the first solid appears first and keeps its own vertices and indices
+    np.testing.assert_array_equal(vertices[:8], verts_a)
+    np.testing.assert_array_equal(tetrahedra[:6], tets_a)
+
+    # the second solid's tets now point at the merged vertices, and every tet
+    # still spans the coordinates it did before the merge
+    assert tetrahedra.max() == 11
+    assert _tet_coordinates(vertices, tetrahedra) == _tet_coordinates(
+        np.vstack([verts_a, verts_b]), np.vstack([tets_a, tets_b + 8])
+    )
+
+
+def test_combine_tet_meshes_leaves_separate_solids_apart():
+    """Solids that do not touch share no vertices, so nothing is merged."""
+    verts_a, tets_a = _box_to_tets(-2, -2, -2, 2, 4, 4)
+    verts_b, tets_b = _box_to_tets(20, -2, -2, 2, 4, 4)
+
+    vertices, tetrahedra = combine_tet_meshes(
+        {
+            1: {"vertices": verts_a, "tetrahedra": tets_a},
+            2: {"vertices": verts_b, "tetrahedra": tets_b},
+        }
+    )
+
+    # nothing is merged on proximity, the two stay as separate bodies
+    assert vertices.shape == (16, 3)
     np.testing.assert_array_equal(vertices[:8], verts_a)
     np.testing.assert_array_equal(vertices[8:], verts_b)
-
-    # Solid 1 tets are unchanged, solid 2 tets are offset by len(verts_a) = 8.
-    np.testing.assert_array_equal(tetrahedra[:6], tets_a)
     np.testing.assert_array_equal(tetrahedra[6:], tets_b + 8)
 
-    # Every index is valid and the two solids reference disjoint vertex ranges.
-    assert tetrahedra.max() == 15
-    assert tetrahedra[:6].max() < 8
-    assert tetrahedra[6:].min() >= 8
+
+def test_combine_tet_meshes_keeps_the_volume():
+    """Merging vertices must not move any geometry."""
+
+    def volume(vertices, tetrahedra):
+        a, b, c, d = (vertices[tetrahedra[:, i]] for i in range(4))
+        return np.abs(np.einsum("ij,ij->i", np.cross(b - a, c - a), d - a) / 6).sum()
+
+    verts_a, tets_a = _box_to_tets(-2, -2, -2, 2, 4, 4)
+    verts_b, tets_b = _box_to_tets(0, -2, -2, 2, 4, 4)
+
+    vertices, tetrahedra = combine_tet_meshes(
+        {
+            1: {"vertices": verts_a, "tetrahedra": tets_a},
+            2: {"vertices": verts_b, "tetrahedra": tets_b},
+        }
+    )
+
+    # two boxes of 2 by 4 by 4
+    assert volume(vertices, tetrahedra) == pytest.approx(64.0)
+    assert not (
+        np.abs(volume(vertices, tetrahedra) - volume(verts_a, tets_a)
+               - volume(verts_b, tets_b)) > 1e-12
+    )
 
 
 def test_combine_tet_meshes_empty():


### PR DESCRIPTION
`combine_tet_meshes` concatenated the per solid vertex arrays, so solids that were
imprinted against each other kept two copies of the vertices on the face they share. The
written mesh looks like one body but is really several that only touch.

That does not matter to OpenMC, which scores per tet. It does matter to anything solving
on the mesh afterwards. A finite element solve sees the shared face as an exterior
boundary on both sides, so a Dirichlet condition lands on it and nothing crosses. Reading
a two volume tally mesh into FEniCS gave a temperature field with a hard discontinuity at
the interface and the enclosed solid sitting near zero.

## The change

The duplicate coordinates are bit for bit identical, so they are merged on an exact match.

- nothing is merged on proximity, so solids that do not touch keep their own vertices and
  stay separate bodies
- vertices keep first appearance order rather than being sorted, so the output stays close
  to what it was
- the tet count does not change, only the indices are remapped
- fewer points also means a smaller file

## Tested

13 geometries, 10 of them multi volume ones from model_benchmark_zoo. Each was meshed once
and the tet data combined both ways, so the only difference between the two results is the
welding.

| geometry | solids | points before | after | welded | regions | degenerate | volume drift |
|---|---|---|---|---|---|---|---|
| TwoTouchingCuboids | 2 | 690 | 649 | 41 | 2 -> 1 | 0 | 0 |
| ThreeTouchingCuboids | 3 | 231 | 205 | 26 | 3 -> 1 | 0 | 0 |
| SphereInBox | 2 | 11155 | 7153 | 4002 | 2 -> 1 | 0 | 0 |
| NestedSphere | 2 | 12931 | 8929 | 4002 | 2 -> 1 | 0 | 0 |
| CylinderInBox | 2 | 2601 | 1957 | 644 | 2 -> 1 | 0 | 0 |
| ConcentricCylinders | 3 | 6461 | 4193 | 2268 | 3 -> 1 | 0 | 0 |
| TJunction | 2 | 510 | 497 | 13 | 2 -> 1 | 0 | 0 |
| CladdedPlate | 3 | 3630 | 3340 | 290 | 3 -> 1 | 0 | 0 |
| FuelPinCell | 3 | 6203 | 4187 | 2016 | 3 -> 1 | 0 | 0 |
| DivertorMonoblock | 2 | 5901 | 5145 | 756 | 2 -> 1 | 0 | 0 |
| BoxWithSphericalCavity | 1 | 4445 | 4445 | 0 | 1 -> 1 | 0 | 0 |
| TwoSeparateCuboids, 40 apart | 2 | 482 | 482 | 0 | 2 -> 2 | 0 | 0 |
| CornerTouch, vertex only | 2 | 482 | 481 | 1 | 2 -> 1 | 0 | 0 |

Volume drift is exactly zero everywhere and no tet ends up using the same vertex twice, so
the merge only re-indexes.

Also run end to end with the cad-to-dagmc-mesher backend on a box with a sphere in it:
251887 tets, 48599 points instead of 49456, one connected region instead of two, total
volume 30528.56 against an analytic 30534.3 which is the sphere faceting. OpenMC scored a
tally on it and FEniCS then solved the heat equation, where the enclosed sphere goes from
4.26e-03 to 4.98e-02 because heat now crosses the interface instead of being cut off by a
boundary condition on the join.

`tests/test_write_vtk.py` gains a test for the weld, one for solids that do not touch, and
one that the volume is unchanged. The existing
`test_combine_tet_meshes_offsets_indices` asserted the old concatenation, 16 vertices with
the second solid offset by 8, so it is rewritten to assert the merged result and to check
every tet still spans the coordinates it did before. 120 tests pass.

## Worth knowing

Two solids meeting at a single corner become one region joined through that one node. It is
faithful to the CAD and fine for a neutronics mesh, which is what this writes. Anyone doing
thermal work properly should remesh the CAD rather than reuse the tally mesh.

The weld relies on both sides of a shared face being tessellated identically, which is what
the mesher does today. If that ever changed for some geometry the coordinates would not
coincide and that pair would quietly stay unwelded, which is why the tests assert connected
region counts rather than just point counts.
